### PR TITLE
Add optional libraryID support across MCP operations

### DIFF
--- a/zotero-mcp-plugin/src/modules/annotationService.ts
+++ b/zotero-mcp-plugin/src/modules/annotationService.ts
@@ -128,9 +128,11 @@ export class AnnotationService {
    * @param itemKey 可选，特定文献的笔记
    * @returns 笔记列表
    */
-  async getAllNotes(itemKey?: string, libraryID?: number): Promise<AnnotationContent[]> {
+  async getAllNotes(
+    itemKey?: string,
+    libraryID: number = Zotero.Libraries.userLibraryID,
+  ): Promise<AnnotationContent[]> {
     try {
-      const targetLibraryID = libraryID ?? Zotero.Libraries.userLibraryID;
       ztoolkit.log(
         `[AnnotationService] Getting all notes${itemKey ? " for item " + itemKey : ""}`,
       );
@@ -140,7 +142,7 @@ export class AnnotationService {
       if (itemKey) {
         // 获取特定文献的笔记
         const parentItem = Zotero.Items.getByLibraryAndKey(
-          targetLibraryID,
+          libraryID,
           itemKey,
         );
         if (!parentItem) {
@@ -152,7 +154,7 @@ export class AnnotationService {
       } else {
         // 获取所有笔记
         const search = new Zotero.Search();
-        (search as any).libraryID = targetLibraryID;
+        (search as any).libraryID = libraryID;
         search.addCondition("itemType", "is", "note");
 
         const itemIds = await search.search();
@@ -191,15 +193,17 @@ export class AnnotationService {
    * @param itemKey PDF文献的Key
    * @returns 注释列表
    */
-  async getPDFAnnotations(itemKey: string, libraryID?: number): Promise<AnnotationContent[]> {
+  async getPDFAnnotations(
+    itemKey: string,
+    libraryID: number = Zotero.Libraries.userLibraryID,
+  ): Promise<AnnotationContent[]> {
     try {
-      const targetLibraryID = libraryID ?? Zotero.Libraries.userLibraryID;
       ztoolkit.log(
         `[AnnotationService] Getting PDF annotations for ${itemKey}`,
       );
 
       const item = Zotero.Items.getByLibraryAndKey(
-        targetLibraryID,
+        libraryID,
         itemKey,
       );
 
@@ -287,7 +291,7 @@ export class AnnotationService {
     );
 
     try {
-      const targetLibraryID = params.libraryID ?? Zotero.Libraries.userLibraryID;
+      const libraryID = params.libraryID ?? Zotero.Libraries.userLibraryID;
       const allAnnotations: AnnotationContent[] = [];
 
       // 获取笔记
@@ -296,21 +300,21 @@ export class AnnotationService {
         params.type === "note" ||
         (Array.isArray(params.type) && params.type.includes("note"))
       ) {
-        const notes = await this.getAllNotes(params.itemKey, targetLibraryID);
+        const notes = await this.getAllNotes(params.itemKey, libraryID);
         allAnnotations.push(...notes);
       }
 
       // 获取PDF注释
       if (!params.type || params.type !== "note") {
         if (params.itemKey) {
-          const pdfAnnotations = await this.getPDFAnnotations(params.itemKey, targetLibraryID);
+          const pdfAnnotations = await this.getPDFAnnotations(params.itemKey, libraryID);
           allAnnotations.push(...pdfAnnotations);
         } else {
           // 直接搜索所有 annotation 类型的 items（更快更准确）
           ztoolkit.log(`[AnnotationService] Searching for all annotation items directly`);
           try {
             const search = new Zotero.Search();
-            (search as any).libraryID = targetLibraryID;
+            (search as any).libraryID = libraryID;
             search.addCondition("itemType", "is", "annotation");
             const annotationIds = await search.search();
             ztoolkit.log(`[AnnotationService] Found ${annotationIds.length} annotation items via search`);
@@ -337,14 +341,14 @@ export class AnnotationService {
           } catch (searchError) {
             ztoolkit.log(`[AnnotationService] Direct annotation search failed: ${searchError}, falling back to item iteration`, "warn");
             // Fallback to old method
-            const allItems = await Zotero.Items.getAll(targetLibraryID);
+            const allItems = await Zotero.Items.getAll(libraryID);
             const itemLimit = 100;
             let processedCount = 0;
             for (const item of allItems) {
               if (processedCount >= itemLimit) break;
               if (item.isRegularItem() && !item.isNote() && !item.isAttachment()) {
                 try {
-                  const pdfAnnotations = await this.getPDFAnnotations(item.key, targetLibraryID);
+                  const pdfAnnotations = await this.getPDFAnnotations(item.key, libraryID);
                   allAnnotations.push(...pdfAnnotations);
                   processedCount++;
                 } catch (e) {
@@ -649,24 +653,26 @@ export class AnnotationService {
   /**
    * 根据ID获取注释的完整内容
    */
-  async getAnnotationById(annotationId: string, libraryID?: number): Promise<AnnotationContent | null> {
+  async getAnnotationById(
+    annotationId: string,
+    libraryID: number = Zotero.Libraries.userLibraryID,
+  ): Promise<AnnotationContent | null> {
     try {
-      const targetLibraryID = libraryID ?? Zotero.Libraries.userLibraryID;
       ztoolkit.log(`[AnnotationService] Getting annotation by ID: ${annotationId}`);
       
       // 尝试从笔记中查找
-      const notes = await this.getAllNotes(undefined, targetLibraryID);
+      const notes = await this.getAllNotes(undefined, libraryID);
       const note = notes.find(n => n.id === annotationId);
       if (note) {
         return note;
       }
 
       // 从所有PDF注释中查找
-      const allItems = await Zotero.Items.getAll(targetLibraryID);
+      const allItems = await Zotero.Items.getAll(libraryID);
       for (const item of allItems.slice(0, 100)) { // 限制搜索范围避免性能问题
         if (item.isRegularItem() && !item.isNote() && !item.isAttachment()) {
           try {
-            const annotations = await this.getPDFAnnotations(item.key, targetLibraryID);
+            const annotations = await this.getPDFAnnotations(item.key, libraryID);
             const annotation = annotations.find(a => a.id === annotationId);
             if (annotation) {
               return annotation;

--- a/zotero-mcp-plugin/src/modules/annotationService.ts
+++ b/zotero-mcp-plugin/src/modules/annotationService.ts
@@ -27,6 +27,7 @@ export interface AnnotationContent {
 
 // 搜索参数
 export interface AnnotationSearchParams {
+  libraryID?: number;
   q?: string; // 搜索关键词
   itemKey?: string; // 特定文献的Key
   type?: string | string[]; // 注释类型过滤
@@ -127,8 +128,9 @@ export class AnnotationService {
    * @param itemKey 可选，特定文献的笔记
    * @returns 笔记列表
    */
-  async getAllNotes(itemKey?: string): Promise<AnnotationContent[]> {
+  async getAllNotes(itemKey?: string, libraryID?: number): Promise<AnnotationContent[]> {
     try {
+      const targetLibraryID = libraryID ?? Zotero.Libraries.userLibraryID;
       ztoolkit.log(
         `[AnnotationService] Getting all notes${itemKey ? " for item " + itemKey : ""}`,
       );
@@ -138,7 +140,7 @@ export class AnnotationService {
       if (itemKey) {
         // 获取特定文献的笔记
         const parentItem = Zotero.Items.getByLibraryAndKey(
-          Zotero.Libraries.userLibraryID,
+          targetLibraryID,
           itemKey,
         );
         if (!parentItem) {
@@ -150,7 +152,7 @@ export class AnnotationService {
       } else {
         // 获取所有笔记
         const search = new Zotero.Search();
-        (search as any).libraryID = Zotero.Libraries.userLibraryID;
+        (search as any).libraryID = targetLibraryID;
         search.addCondition("itemType", "is", "note");
 
         const itemIds = await search.search();
@@ -189,14 +191,15 @@ export class AnnotationService {
    * @param itemKey PDF文献的Key
    * @returns 注释列表
    */
-  async getPDFAnnotations(itemKey: string): Promise<AnnotationContent[]> {
+  async getPDFAnnotations(itemKey: string, libraryID?: number): Promise<AnnotationContent[]> {
     try {
+      const targetLibraryID = libraryID ?? Zotero.Libraries.userLibraryID;
       ztoolkit.log(
         `[AnnotationService] Getting PDF annotations for ${itemKey}`,
       );
 
       const item = Zotero.Items.getByLibraryAndKey(
-        Zotero.Libraries.userLibraryID,
+        targetLibraryID,
         itemKey,
       );
 
@@ -284,6 +287,7 @@ export class AnnotationService {
     );
 
     try {
+      const targetLibraryID = params.libraryID ?? Zotero.Libraries.userLibraryID;
       const allAnnotations: AnnotationContent[] = [];
 
       // 获取笔记
@@ -292,21 +296,21 @@ export class AnnotationService {
         params.type === "note" ||
         (Array.isArray(params.type) && params.type.includes("note"))
       ) {
-        const notes = await this.getAllNotes(params.itemKey);
+        const notes = await this.getAllNotes(params.itemKey, targetLibraryID);
         allAnnotations.push(...notes);
       }
 
       // 获取PDF注释
       if (!params.type || params.type !== "note") {
         if (params.itemKey) {
-          const pdfAnnotations = await this.getPDFAnnotations(params.itemKey);
+          const pdfAnnotations = await this.getPDFAnnotations(params.itemKey, targetLibraryID);
           allAnnotations.push(...pdfAnnotations);
         } else {
           // 直接搜索所有 annotation 类型的 items（更快更准确）
           ztoolkit.log(`[AnnotationService] Searching for all annotation items directly`);
           try {
             const search = new Zotero.Search();
-            (search as any).libraryID = Zotero.Libraries.userLibraryID;
+            (search as any).libraryID = targetLibraryID;
             search.addCondition("itemType", "is", "annotation");
             const annotationIds = await search.search();
             ztoolkit.log(`[AnnotationService] Found ${annotationIds.length} annotation items via search`);
@@ -333,14 +337,14 @@ export class AnnotationService {
           } catch (searchError) {
             ztoolkit.log(`[AnnotationService] Direct annotation search failed: ${searchError}, falling back to item iteration`, "warn");
             // Fallback to old method
-            const allItems = await Zotero.Items.getAll(Zotero.Libraries.userLibraryID);
+            const allItems = await Zotero.Items.getAll(targetLibraryID);
             const itemLimit = 100;
             let processedCount = 0;
             for (const item of allItems) {
               if (processedCount >= itemLimit) break;
               if (item.isRegularItem() && !item.isNote() && !item.isAttachment()) {
                 try {
-                  const pdfAnnotations = await this.getPDFAnnotations(item.key);
+                  const pdfAnnotations = await this.getPDFAnnotations(item.key, targetLibraryID);
                   allAnnotations.push(...pdfAnnotations);
                   processedCount++;
                 } catch (e) {
@@ -645,23 +649,24 @@ export class AnnotationService {
   /**
    * 根据ID获取注释的完整内容
    */
-  async getAnnotationById(annotationId: string): Promise<AnnotationContent | null> {
+  async getAnnotationById(annotationId: string, libraryID?: number): Promise<AnnotationContent | null> {
     try {
+      const targetLibraryID = libraryID ?? Zotero.Libraries.userLibraryID;
       ztoolkit.log(`[AnnotationService] Getting annotation by ID: ${annotationId}`);
       
       // 尝试从笔记中查找
-      const notes = await this.getAllNotes();
+      const notes = await this.getAllNotes(undefined, targetLibraryID);
       const note = notes.find(n => n.id === annotationId);
       if (note) {
         return note;
       }
 
       // 从所有PDF注释中查找
-      const allItems = await Zotero.Items.getAll(Zotero.Libraries.userLibraryID);
+      const allItems = await Zotero.Items.getAll(targetLibraryID);
       for (const item of allItems.slice(0, 100)) { // 限制搜索范围避免性能问题
         if (item.isRegularItem() && !item.isNote() && !item.isAttachment()) {
           try {
-            const annotations = await this.getPDFAnnotations(item.key);
+            const annotations = await this.getPDFAnnotations(item.key, targetLibraryID);
             const annotation = annotations.find(a => a.id === annotationId);
             if (annotation) {
               return annotation;
@@ -682,14 +687,14 @@ export class AnnotationService {
   /**
    * 批量获取注释的完整内容
    */
-  async getAnnotationsByIds(annotationIds: string[]): Promise<AnnotationContent[]> {
+  async getAnnotationsByIds(annotationIds: string[], libraryID?: number): Promise<AnnotationContent[]> {
     try {
       ztoolkit.log(`[AnnotationService] Getting annotations by IDs: ${annotationIds.join(", ")}`);
       
       const results: AnnotationContent[] = [];
       
       for (const id of annotationIds) {
-        const annotation = await this.getAnnotationById(id);
+        const annotation = await this.getAnnotationById(id, libraryID);
         if (annotation) {
           results.push(annotation);
         }

--- a/zotero-mcp-plugin/src/modules/apiHandlers.ts
+++ b/zotero-mcp-plugin/src/modules/apiHandlers.ts
@@ -61,11 +61,20 @@ export async function handlePing(): Promise<HttpResponse> {
 
 /**
  * Handles listing all available Zotero libraries.
+ * @param query - URL query parameters.
  * @returns A promise that resolves to an HttpResponse.
  */
-export async function handleGetLibraries(): Promise<HttpResponse> {
+export async function handleGetLibraries(
+  query: URLSearchParams,
+): Promise<HttpResponse> {
   try {
-    const libraries = Zotero.Libraries.getAll().map((library) => ({
+    const limit = parseInt(query.get("limit") || "100", 10);
+    const offset = parseInt(query.get("offset") || "0", 10);
+
+    const allLibraries = Zotero.Libraries.getAll();
+    const total = allLibraries.length;
+    const paginated = allLibraries.slice(offset, offset + limit);
+    const libraries = paginated.map((library) => ({
       libraryID: library.libraryID,
       name: library.name,
       libraryType: library.libraryType,
@@ -74,8 +83,11 @@ export async function handleGetLibraries(): Promise<HttpResponse> {
     return {
       status: 200,
       statusText: "OK",
-      headers: { "Content-Type": "application/json; charset=utf-8" },
-      body: JSON.stringify({ libraries }),
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        "X-Total-Count": total.toString(),
+      },
+      body: JSON.stringify(libraries),
     };
   } catch (e) {
     const error = e instanceof Error ? e : new Error(String(e));

--- a/zotero-mcp-plugin/src/modules/apiHandlers.ts
+++ b/zotero-mcp-plugin/src/modules/apiHandlers.ts
@@ -90,6 +90,63 @@ export async function handleGetLibraries(): Promise<HttpResponse> {
 }
 
 /**
+ * Handles searching Zotero libraries by name.
+ * @param query - URL query parameters.
+ * @returns A promise that resolves to an HttpResponse.
+ */
+export async function handleSearchLibraries(
+  query: URLSearchParams,
+): Promise<HttpResponse> {
+  try {
+    const q = query.get("q");
+    if (!q) {
+      return {
+        status: 400,
+        statusText: "Bad Request",
+        headers: { "Content-Type": "application/json; charset=utf-8" },
+        body: JSON.stringify({ error: "Missing query parameter 'q'" }),
+      };
+    }
+
+    const limit = parseInt(query.get("limit") || "100", 10);
+    const offset = parseInt(query.get("offset") || "0", 10);
+    const lowerCaseQuery = q.toLowerCase();
+
+    const matchedLibraries = Zotero.Libraries.getAll().filter((library) =>
+      library.name.toLowerCase().includes(lowerCaseQuery),
+    );
+
+    const total = matchedLibraries.length;
+    const paginated = matchedLibraries.slice(offset, offset + limit);
+    const libraries = paginated.map((library) => ({
+      libraryID: library.libraryID,
+      name: library.name,
+      libraryType: library.libraryType,
+    }));
+
+    return {
+      status: 200,
+      statusText: "OK",
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        "X-Total-Count": total.toString(),
+      },
+      body: JSON.stringify(libraries),
+    };
+  } catch (e) {
+    const error = e instanceof Error ? e : new Error(String(e));
+    const status = (error as any).status || 500;
+    Zotero.logError(error);
+    return {
+      status,
+      statusText: status === 400 ? "Bad Request" : "Internal Server Error",
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+      body: JSON.stringify({ error: status === 400 ? error.message : "An unexpected error occurred" }),
+    };
+  }
+}
+
+/**
  * Handles the /items/:itemKey endpoint to retrieve a single item.
  * @param params - URL parameters, where params[1] is the itemKey.
  * @param query - URL query parameters, may contain 'fields'.

--- a/zotero-mcp-plugin/src/modules/apiHandlers.ts
+++ b/zotero-mcp-plugin/src/modules/apiHandlers.ts
@@ -41,6 +41,36 @@ export async function handlePing(): Promise<HttpResponse> {
 }
 
 /**
+ * Handles listing all available Zotero libraries.
+ * @returns A promise that resolves to an HttpResponse.
+ */
+export async function handleGetLibraries(): Promise<HttpResponse> {
+  try {
+    const libraries = Zotero.Libraries.getAll().map((library) => ({
+      libraryID: library.libraryID,
+      name: library.name,
+      libraryType: library.libraryType,
+    }));
+
+    return {
+      status: 200,
+      statusText: "OK",
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+      body: JSON.stringify({ libraries }),
+    };
+  } catch (e) {
+    const error = e instanceof Error ? e : new Error(String(e));
+    Zotero.logError(error);
+    return {
+      status: 500,
+      statusText: "Internal Server Error",
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+      body: JSON.stringify({ error: "An unexpected error occurred" }),
+    };
+  }
+}
+
+/**
  * Handles the /items/:itemKey endpoint to retrieve a single item.
  * @param params - URL parameters, where params[1] is the itemKey.
  * @param query - URL query parameters, may contain 'fields'.

--- a/zotero-mcp-plugin/src/modules/apiHandlers.ts
+++ b/zotero-mcp-plugin/src/modules/apiHandlers.ts
@@ -11,7 +11,7 @@ import {
   formatCollectionDetails,
   formatCollectionTree,
 } from "./collectionFormatter";
-import { handleSearchRequest } from "./searchEngine";
+import { handleSearchRequest, MCPError } from "./searchEngine";
 import { FulltextService } from "./fulltextService";
 
 declare let ztoolkit: ZToolkit;
@@ -22,6 +22,25 @@ interface HttpResponse {
   statusText: string;
   headers?: Record<string, string>;
   body?: string;
+}
+
+function resolveLibraryID(query: URLSearchParams): number {
+  const rawLibraryID = query.get("libraryID");
+  if (rawLibraryID === null) {
+    return Zotero.Libraries.userLibraryID;
+  }
+
+  // Treat empty or whitespace-only values the same as an omitted libraryID.
+  if (!rawLibraryID.trim()) {
+    return Zotero.Libraries.userLibraryID;
+  }
+
+  const libraryID = Number(rawLibraryID);
+  if (!Number.isInteger(libraryID) || !Number.isFinite(libraryID)) {
+    throw new MCPError(400, "Invalid libraryID: must be an integer");
+  }
+
+  return libraryID;
 }
 
 /**
@@ -153,6 +172,11 @@ export async function handleSearch(
       }
     }
 
+    const libraryID = resolveLibraryID(query);
+    if (query.has("libraryID")) {
+      searchParams.libraryID = String(libraryID);
+    }
+
     // Backward compatibility: if 'tag' is present but 'tags' is not, use 'tag'
     if (searchParams.tag && !searchParams.tags) {
       searchParams.tags = [searchParams.tag];
@@ -224,9 +248,7 @@ export async function handleGetCollections(
   query: URLSearchParams,
 ): Promise<HttpResponse> {
   try {
-    const libraryID =
-      parseInt(query.get("libraryID") || "", 10) ||
-      Zotero.Libraries.userLibraryID;
+    const libraryID = resolveLibraryID(query);
     const limit = parseInt(query.get("limit") || "100", 10);
     const offset = parseInt(query.get("offset") || "0", 10);
     const sort = query.get("sort") || "name";
@@ -294,12 +316,13 @@ export async function handleGetCollections(
     };
   } catch (e) {
     const error = e instanceof Error ? e : new Error(String(e));
+    const status = (error as any).status || 500;
     Zotero.logError(error);
     return {
-      status: 500,
-      statusText: "Internal Server Error",
+      status,
+      statusText: status === 400 ? "Bad Request" : "Internal Server Error",
       headers: { "Content-Type": "application/json; charset=utf-8" },
-      body: JSON.stringify({ error: "An unexpected error occurred" }),
+      body: JSON.stringify({ error: status === 400 ? error.message : "An unexpected error occurred" }),
     };
   }
 }
@@ -322,9 +345,7 @@ export async function handleSearchCollections(
         body: JSON.stringify({ error: "Missing query parameter 'q'" }),
       };
     }
-    const libraryID =
-      parseInt(query.get("libraryID") || "", 10) ||
-      Zotero.Libraries.userLibraryID;
+    const libraryID = resolveLibraryID(query);
     const limit = parseInt(query.get("limit") || "100", 10);
     const offset = parseInt(query.get("offset") || "0", 10);
 
@@ -351,12 +372,13 @@ export async function handleSearchCollections(
     };
   } catch (e) {
     const error = e instanceof Error ? e : new Error(String(e));
+    const status = (error as any).status || 500;
     Zotero.logError(error);
     return {
-      status: 500,
-      statusText: "Internal Server Error",
+      status,
+      statusText: status === 400 ? "Bad Request" : "Internal Server Error",
       headers: { "Content-Type": "application/json; charset=utf-8" },
-      body: JSON.stringify({ error: "An unexpected error occurred" }),
+      body: JSON.stringify({ error: status === 400 ? error.message : "An unexpected error occurred" }),
     };
   }
 }
@@ -381,9 +403,7 @@ export async function handleGetCollectionDetails(
         body: JSON.stringify({ error: "Missing collectionKey parameter" }),
       };
     }
-    const libraryID =
-      parseInt(query.get("libraryID") || "", 10) ||
-      Zotero.Libraries.userLibraryID;
+    const libraryID = resolveLibraryID(query);
 
     const collection = Zotero.Collections.getByLibraryAndKey(
       libraryID,
@@ -415,12 +435,13 @@ export async function handleGetCollectionDetails(
     };
   } catch (e) {
     const error = e instanceof Error ? e : new Error(String(e));
+    const status = (error as any).status || 500;
     Zotero.logError(error);
     return {
-      status: 500,
-      statusText: "Internal Server Error",
+      status,
+      statusText: status === 400 ? "Bad Request" : "Internal Server Error",
       headers: { "Content-Type": "application/json; charset=utf-8" },
-      body: JSON.stringify({ error: "An unexpected error occurred" }),
+      body: JSON.stringify({ error: status === 400 ? error.message : "An unexpected error occurred" }),
     };
   }
 }
@@ -447,9 +468,7 @@ export async function handleGetCollectionItems(
         body: JSON.stringify({ error: "Missing collectionKey parameter" }),
       };
     }
-    const libraryID =
-      parseInt(query.get("libraryID") || "", 10) ||
-      Zotero.Libraries.userLibraryID;
+    const libraryID = resolveLibraryID(query);
 
     ztoolkit.log(`[ApiHandlers] Using libraryID: ${libraryID}`);
 
@@ -504,14 +523,15 @@ export async function handleGetCollectionItems(
     };
   } catch (e) {
     const error = e instanceof Error ? e : new Error(String(e));
+    const status = (error as any).status || 500;
     ztoolkit.log(`[ApiHandlers] Error in handleGetCollectionItems: ${error.message}`, "error");
     ztoolkit.log(`[ApiHandlers] Error stack: ${error.stack}`, "error");
     Zotero.logError(error);
     return {
-      status: 500,
-      statusText: "Internal Server Error",
+      status,
+      statusText: status === 400 ? "Bad Request" : "Internal Server Error",
       headers: { "Content-Type": "application/json; charset=utf-8" },
-      body: JSON.stringify({ error: "An unexpected error occurred" }),
+      body: JSON.stringify({ error: status === 400 ? error.message : "An unexpected error occurred" }),
     };
   }
 }
@@ -539,9 +559,7 @@ export async function handleGetSubcollections(
       };
     }
     
-    const libraryID =
-      parseInt(query.get("libraryID") || "", 10) ||
-      Zotero.Libraries.userLibraryID;
+    const libraryID = resolveLibraryID(query);
 
     ztoolkit.log(`[ApiHandlers] Using libraryID: ${libraryID}`);
 
@@ -613,14 +631,15 @@ export async function handleGetSubcollections(
     };
   } catch (e) {
     const error = e instanceof Error ? e : new Error(String(e));
+    const status = (error as any).status || 500;
     ztoolkit.log(`[ApiHandlers] Error in handleGetSubcollections: ${error.message}`, "error");
     ztoolkit.log(`[ApiHandlers] Error stack: ${error.stack}`, "error");
     Zotero.logError(error);
     return {
-      status: 500,
-      statusText: "Internal Server Error",
+      status,
+      statusText: status === 400 ? "Bad Request" : "Internal Server Error",
       headers: { "Content-Type": "application/json; charset=utf-8" },
-      body: JSON.stringify({ error: "An unexpected error occurred" }),
+      body: JSON.stringify({ error: status === 400 ? error.message : "An unexpected error occurred" }),
     };
   }
 }

--- a/zotero-mcp-plugin/src/modules/apiHandlers.ts
+++ b/zotero-mcp-plugin/src/modules/apiHandlers.ts
@@ -1059,7 +1059,7 @@ export async function handleGetItemAbstract(
  * Handles creating a new collection.
  */
 export async function handleCreateCollection(
-  body: { name: string; parentCollection?: string },
+  body: { name: string; parentCollection?: string; libraryID?: number },
 ): Promise<HttpResponse> {
   try {
     if (!body.name || body.name.trim().length === 0) {
@@ -1071,7 +1071,7 @@ export async function handleCreateCollection(
       };
     }
 
-    const libraryID = Zotero.Libraries.userLibraryID;
+    const libraryID = body.libraryID ?? Zotero.Libraries.userLibraryID;
     const collection = new Zotero.Collection();
     (collection as any).libraryID = libraryID;
     collection.name = body.name.trim();
@@ -1087,7 +1087,7 @@ export async function handleCreateCollection(
           statusText: "Not Found",
           headers: { "Content-Type": "application/json; charset=utf-8" },
           body: JSON.stringify({
-            error: `Parent collection ${body.parentCollection} not found`,
+            error: `Parent collection ${body.parentCollection} not found in library ${libraryID}`,
           }),
         };
       }
@@ -1120,7 +1120,7 @@ export async function handleCreateCollection(
  */
 export async function handleUpdateCollection(
   params: Record<string, string>,
-  body: { name?: string; parentCollection?: string },
+  body: { name?: string; parentCollection?: string; libraryID?: number },
 ): Promise<HttpResponse> {
   try {
     const collectionKey = params[1];
@@ -1133,7 +1133,7 @@ export async function handleUpdateCollection(
       };
     }
 
-    const libraryID = Zotero.Libraries.userLibraryID;
+    const libraryID = body.libraryID ?? Zotero.Libraries.userLibraryID;
     const collection = Zotero.Collections.getByLibraryAndKey(
       libraryID,
       collectionKey,
@@ -1145,7 +1145,7 @@ export async function handleUpdateCollection(
         statusText: "Not Found",
         headers: { "Content-Type": "application/json; charset=utf-8" },
         body: JSON.stringify({
-          error: `Collection with key ${collectionKey} not found`,
+          error: `Collection with key ${collectionKey} not found in library ${libraryID}`,
         }),
       };
     }
@@ -1185,7 +1185,7 @@ export async function handleUpdateCollection(
             statusText: "Not Found",
             headers: { "Content-Type": "application/json; charset=utf-8" },
             body: JSON.stringify({
-              error: `Parent collection ${body.parentCollection} not found`,
+              error: `Parent collection ${body.parentCollection} not found in library ${libraryID}`,
             }),
           };
         }
@@ -1229,7 +1229,7 @@ export async function handleUpdateCollection(
  */
 export async function handleDeleteCollection(
   params: Record<string, string>,
-  body: { deleteItems?: boolean },
+  body: { deleteItems?: boolean; libraryID?: number },
 ): Promise<HttpResponse> {
   try {
     const collectionKey = params[1];
@@ -1242,7 +1242,7 @@ export async function handleDeleteCollection(
       };
     }
 
-    const libraryID = Zotero.Libraries.userLibraryID;
+    const libraryID = body.libraryID ?? Zotero.Libraries.userLibraryID;
     const collection = Zotero.Collections.getByLibraryAndKey(
       libraryID,
       collectionKey,
@@ -1254,7 +1254,7 @@ export async function handleDeleteCollection(
         statusText: "Not Found",
         headers: { "Content-Type": "application/json; charset=utf-8" },
         body: JSON.stringify({
-          error: `Collection with key ${collectionKey} not found`,
+          error: `Collection with key ${collectionKey} not found in library ${libraryID}`,
         }),
       };
     }
@@ -1298,7 +1298,7 @@ export async function handleDeleteCollection(
  */
 export async function handleAddItemsToCollection(
   params: Record<string, string>,
-  body: { itemKeys: string[] },
+  body: { itemKeys: string[]; libraryID?: number },
 ): Promise<HttpResponse> {
   try {
     const collectionKey = params[1];
@@ -1320,7 +1320,7 @@ export async function handleAddItemsToCollection(
       };
     }
 
-    const libraryID = Zotero.Libraries.userLibraryID;
+    const libraryID = body.libraryID ?? Zotero.Libraries.userLibraryID;
     const collection = Zotero.Collections.getByLibraryAndKey(
       libraryID,
       collectionKey,
@@ -1332,7 +1332,7 @@ export async function handleAddItemsToCollection(
         statusText: "Not Found",
         headers: { "Content-Type": "application/json; charset=utf-8" },
         body: JSON.stringify({
-          error: `Collection with key ${collectionKey} not found`,
+          error: `Collection with key ${collectionKey} not found in library ${libraryID}`,
         }),
       };
     }
@@ -1396,7 +1396,7 @@ export async function handleAddItemsToCollection(
  */
 export async function handleRemoveItemsFromCollection(
   params: Record<string, string>,
-  body: { itemKeys: string[] },
+  body: { itemKeys: string[]; libraryID?: number },
 ): Promise<HttpResponse> {
   try {
     const collectionKey = params[1];
@@ -1418,7 +1418,7 @@ export async function handleRemoveItemsFromCollection(
       };
     }
 
-    const libraryID = Zotero.Libraries.userLibraryID;
+    const libraryID = body.libraryID ?? Zotero.Libraries.userLibraryID;
     const collection = Zotero.Collections.getByLibraryAndKey(
       libraryID,
       collectionKey,
@@ -1430,7 +1430,7 @@ export async function handleRemoveItemsFromCollection(
         statusText: "Not Found",
         headers: { "Content-Type": "application/json; charset=utf-8" },
         body: JSON.stringify({
-          error: `Collection with key ${collectionKey} not found`,
+          error: `Collection with key ${collectionKey} not found in library ${libraryID}`,
         }),
       };
     }

--- a/zotero-mcp-plugin/src/modules/apiHandlers.ts
+++ b/zotero-mcp-plugin/src/modules/apiHandlers.ts
@@ -179,8 +179,9 @@ export async function handleGetItem(
   }
 
   try {
+    const libraryID = resolveLibraryID(query);
     const item = Zotero.Items.getByLibraryAndKey(
-      Zotero.Libraries.userLibraryID,
+      libraryID,
       itemKey,
     );
 
@@ -205,12 +206,13 @@ export async function handleGetItem(
     };
   } catch (e) {
     const error = e instanceof Error ? e : new Error(String(e));
+    const status = (error as any).status || 500;
     Zotero.logError(error);
     return {
-      status: 500,
-      statusText: "Internal Server Error",
+      status,
+      statusText: status === 400 ? "Bad Request" : "Internal Server Error",
       headers: { "Content-Type": "application/json; charset=utf-8" },
-      body: JSON.stringify({ error: "An unexpected error occurred" }),
+      body: JSON.stringify({ error: status === 400 ? error.message : "An unexpected error occurred" }),
     };
   }
 }
@@ -924,10 +926,12 @@ export async function handleSearchFulltext(
   ztoolkit.log(`[MCP ApiHandlers] Searching fulltext for: "${q}"`);
 
   try {
+    const libraryID = resolveLibraryID(query);
     const fulltextService = new FulltextService();
     
     // Parse search options
     const options = {
+      libraryID,
       itemKeys: query.get("itemKeys")?.split(",") || null,
       contextLength: parseInt(query.get("contextLength") || "200", 10),
       maxResults: Math.min(parseInt(query.get("maxResults") || "50", 10), 200),
@@ -944,6 +948,7 @@ export async function handleSearchFulltext(
     };
   } catch (e) {
     const error = e instanceof Error ? e : new Error(String(e));
+    const status = (error as any).status || 500;
     ztoolkit.log(
       `[MCP ApiHandlers] Error in handleSearchFulltext: ${error.message}`,
       "error",
@@ -951,10 +956,10 @@ export async function handleSearchFulltext(
     Zotero.logError(error);
 
     return {
-      status: 500,
-      statusText: "Internal Server Error",
+      status,
+      statusText: status === 400 ? "Bad Request" : "Internal Server Error",
       headers: { "Content-Type": "application/json; charset=utf-8" },
-      body: JSON.stringify({ error: "An unexpected error occurred" }),
+      body: JSON.stringify({ error: status === 400 ? error.message : "An unexpected error occurred" }),
     };
   }
 }
@@ -982,8 +987,9 @@ export async function handleGetItemAbstract(
   ztoolkit.log(`[MCP ApiHandlers] Getting abstract for item ${itemKey}`);
 
   try {
+    const libraryID = resolveLibraryID(query);
     const item = Zotero.Items.getByLibraryAndKey(
-      Zotero.Libraries.userLibraryID,
+      libraryID,
       itemKey,
     );
 
@@ -1033,6 +1039,7 @@ export async function handleGetItemAbstract(
     }
   } catch (e) {
     const error = e instanceof Error ? e : new Error(String(e));
+    const status = (error as any).status || 500;
     ztoolkit.log(
       `[MCP ApiHandlers] Error in handleGetItemAbstract: ${error.message}`,
       "error",
@@ -1040,10 +1047,10 @@ export async function handleGetItemAbstract(
     Zotero.logError(error);
 
     return {
-      status: 500,
-      statusText: "Internal Server Error",
+      status,
+      statusText: status === 400 ? "Bad Request" : "Internal Server Error",
       headers: { "Content-Type": "application/json; charset=utf-8" },
-      body: JSON.stringify({ error: "An unexpected error occurred" }),
+      body: JSON.stringify({ error: status === 400 ? error.message : "An unexpected error occurred" }),
     };
   }
 }

--- a/zotero-mcp-plugin/src/modules/fulltextService.ts
+++ b/zotero-mcp-plugin/src/modules/fulltextService.ts
@@ -12,10 +12,12 @@ export class FulltextService {
    * @param itemKey - The item key
    * @returns Object containing all available text content
    */
-  async getItemFulltext(itemKey: string, libraryID?: number): Promise<any> {
+  async getItemFulltext(
+    itemKey: string,
+    libraryID: number = Zotero.Libraries.userLibraryID,
+  ): Promise<any> {
     try {
-      const targetLibraryID = libraryID ?? Zotero.Libraries.userLibraryID;
-      const item = Zotero.Items.getByLibraryAndKey(targetLibraryID, itemKey);
+      const item = Zotero.Items.getByLibraryAndKey(libraryID, itemKey);
       if (!item) {
         throw new Error(`Item with key ${itemKey} not found`);
       }
@@ -277,8 +279,6 @@ export class FulltextService {
         maxResults = 50,
         caseSensitive = false
       } = options;
-      const targetLibraryID = libraryID ?? Zotero.Libraries.userLibraryID;
-
       ztoolkit.log(`[FulltextService] Searching fulltext for: "${query}"`);
 
       const results = [];
@@ -291,11 +291,11 @@ export class FulltextService {
       let itemsToSearch;
       if (itemKeys && Array.isArray(itemKeys)) {
         itemsToSearch = itemKeys.map(key => 
-          Zotero.Items.getByLibraryAndKey(targetLibraryID, key)
+          Zotero.Items.getByLibraryAndKey(libraryID, key)
         ).filter(item => item);
       } else {
         // Search all items (limit for performance)
-        const allItems = await Zotero.Items.getAll(targetLibraryID);
+        const allItems = await Zotero.Items.getAll(libraryID);
         itemsToSearch = allItems.slice(0, 1000); // Limit for performance
       }
 
@@ -303,7 +303,7 @@ export class FulltextService {
         if (results.length >= maxResults) break;
 
         try {
-          const fulltext = await this.getItemFulltext(item.key, targetLibraryID);
+          const fulltext = await this.getItemFulltext(item.key, libraryID);
           const matches = [];
 
           // Search in different content types

--- a/zotero-mcp-plugin/src/modules/fulltextService.ts
+++ b/zotero-mcp-plugin/src/modules/fulltextService.ts
@@ -7,15 +7,15 @@ declare let Zotero: any;
 declare let ztoolkit: ZToolkit;
 
 export class FulltextService {
-  
   /**
    * Get comprehensive fulltext content for an item
    * @param itemKey - The item key
    * @returns Object containing all available text content
    */
-  async getItemFulltext(itemKey: string): Promise<any> {
+  async getItemFulltext(itemKey: string, libraryID?: number): Promise<any> {
     try {
-      const item = Zotero.Items.getByLibraryAndKey(Zotero.Libraries.userLibraryID, itemKey);
+      const targetLibraryID = libraryID ?? Zotero.Libraries.userLibraryID;
+      const item = Zotero.Items.getByLibraryAndKey(targetLibraryID, itemKey);
       if (!item) {
         throw new Error(`Item with key ${itemKey} not found`);
       }
@@ -271,11 +271,13 @@ export class FulltextService {
   async searchFulltext(query: string, options: any = {}): Promise<any> {
     try {
       const {
+        libraryID,
         itemKeys = null,
         contextLength = 200,
         maxResults = 50,
         caseSensitive = false
       } = options;
+      const targetLibraryID = libraryID ?? Zotero.Libraries.userLibraryID;
 
       ztoolkit.log(`[FulltextService] Searching fulltext for: "${query}"`);
 
@@ -289,11 +291,11 @@ export class FulltextService {
       let itemsToSearch;
       if (itemKeys && Array.isArray(itemKeys)) {
         itemsToSearch = itemKeys.map(key => 
-          Zotero.Items.getByLibraryAndKey(Zotero.Libraries.userLibraryID, key)
+          Zotero.Items.getByLibraryAndKey(targetLibraryID, key)
         ).filter(item => item);
       } else {
         // Search all items (limit for performance)
-        const allItems = await Zotero.Items.getAll(Zotero.Libraries.userLibraryID);
+        const allItems = await Zotero.Items.getAll(targetLibraryID);
         itemsToSearch = allItems.slice(0, 1000); // Limit for performance
       }
 
@@ -301,7 +303,7 @@ export class FulltextService {
         if (results.length >= maxResults) break;
 
         try {
-          const fulltext = await this.getItemFulltext(item.key);
+          const fulltext = await this.getItemFulltext(item.key, targetLibraryID);
           const matches = [];
 
           // Search in different content types

--- a/zotero-mcp-plugin/src/modules/httpServer.ts
+++ b/zotero-mcp-plugin/src/modules/httpServer.ts
@@ -777,6 +777,7 @@ private getCapabilities() {
         description: "Search the Zotero library with advanced parameters including boolean operators, relevance scoring, fulltext search, and pagination. Returns: {query, pagination, searchTime, results: [{key, title, creators, date, attachments: [{key, filename, filePath, contentType, linkMode}], fulltextMatch: {query, mode, attachments: [{snippet, score}], notes: [{snippet, score}]}}], searchFeatures, version}",
         category: "search",
         parameters: {
+          libraryID: { type: "number", description: "Optional target Zotero library ID. Defaults to the user library when omitted.", required: false },
           q: { type: "string", description: "General search query", required: false },
           title: { type: "string", description: "Title search", required: false },
           titleOperator: { 
@@ -884,6 +885,7 @@ private getCapabilities() {
         description: "Get list of all collections in the library",
         category: "collections",
         parameters: {
+          libraryID: { type: "number", description: "Optional target Zotero library ID. Defaults to the user library when omitted.", required: false },
           limit: { type: "number", description: "Maximum results to return", required: false },
           offset: { type: "number", description: "Pagination offset", required: false }
         }
@@ -893,6 +895,7 @@ private getCapabilities() {
         description: "Search collections by name",
         category: "collections",
         parameters: {
+          libraryID: { type: "number", description: "Optional target Zotero library ID. Defaults to the user library when omitted.", required: false },
           q: { type: "string", description: "Collection name search query", required: true },
           limit: { type: "number", description: "Maximum results to return", required: false }
         }
@@ -902,7 +905,8 @@ private getCapabilities() {
         description: "Get detailed information about a specific collection",
         category: "collections",
         parameters: {
-          collectionKey: { type: "string", description: "Collection key", required: true }
+          collectionKey: { type: "string", description: "Collection key", required: true },
+          libraryID: { type: "number", description: "Optional target Zotero library ID. Defaults to the user library when omitted.", required: false }
         }
       },
       {
@@ -911,6 +915,7 @@ private getCapabilities() {
         category: "collections",
         parameters: {
           collectionKey: { type: "string", description: "Collection key", required: true },
+          libraryID: { type: "number", description: "Optional target Zotero library ID. Defaults to the user library when omitted.", required: false },
           limit: { type: "number", description: "Maximum results to return", required: false },
           offset: { type: "number", description: "Pagination offset", required: false }
         }

--- a/zotero-mcp-plugin/src/modules/httpServer.ts
+++ b/zotero-mcp-plugin/src/modules/httpServer.ts
@@ -773,6 +773,16 @@ private getCapabilities() {
         parameters: {}
       },
       {
+        name: "search_libraries",
+        description: "Search libraries by name. Returns: [{libraryID, name, libraryType}]",
+        category: "retrieval",
+        parameters: {
+          q: { type: "string", description: "Library name search query", required: true },
+          limit: { type: "number", description: "Maximum results to return", required: false },
+          offset: { type: "number", description: "Pagination offset", required: false }
+        }
+      },
+      {
         name: "search_library",
         description: "Search the Zotero library with advanced parameters including boolean operators, relevance scoring, fulltext search, and pagination. Returns: {query, pagination, searchTime, results: [{key, title, creators, date, attachments: [{key, filename, filePath, contentType, linkMode}], fulltextMatch: {query, mode, attachments: [{snippet, score}], notes: [{snippet, score}]}}], searchFeatures, version}",
         category: "search",
@@ -897,7 +907,8 @@ private getCapabilities() {
         parameters: {
           libraryID: { type: "number", description: "Optional target Zotero library ID. Defaults to the user library when omitted.", required: false },
           q: { type: "string", description: "Collection name search query", required: true },
-          limit: { type: "number", description: "Maximum results to return", required: false }
+          limit: { type: "number", description: "Maximum results to return", required: false },
+          offset: { type: "number", description: "Pagination offset", required: false }
         }
       },
       {

--- a/zotero-mcp-plugin/src/modules/httpServer.ts
+++ b/zotero-mcp-plugin/src/modules/httpServer.ts
@@ -767,6 +767,12 @@ private getCapabilities() {
     },
     tools: [
       {
+        name: "get_libraries",
+        description: "List all Zotero libraries available in the current client. Returns: {libraries: [{libraryID, name, libraryType}]}",
+        category: "retrieval",
+        parameters: {}
+      },
+      {
         name: "search_library",
         description: "Search the Zotero library with advanced parameters including boolean operators, relevance scoring, fulltext search, and pagination. Returns: {query, pagination, searchTime, results: [{key, title, creators, date, attachments: [{key, filename, filePath, contentType, linkMode}], fulltextMatch: {query, mode, attachments: [{snippet, score}], notes: [{snippet, score}]}}], searchFeatures, version}",
         category: "search",

--- a/zotero-mcp-plugin/src/modules/httpServer.ts
+++ b/zotero-mcp-plugin/src/modules/httpServer.ts
@@ -836,6 +836,7 @@ private getCapabilities() {
         description: "Search all notes, PDF annotations and highlights with smart content processing",
         category: "search",
         parameters: {
+          libraryID: { type: "number", description: "Optional target Zotero library ID. Defaults to the user library when omitted.", required: false },
           q: { type: "string", description: "Search query for content, comments, and tags", required: false },
           type: { 
             type: "string", 
@@ -857,6 +858,7 @@ private getCapabilities() {
         description: "Get detailed information for a specific item including metadata, abstract, attachments info, notes, and tags but not fulltext content. Returns: {key, title, creators, date, itemType, publicationTitle, volume, issue, pages, DOI, url, abstractNote, tags, notes: [note_content], attachments: [{key, title, path, contentType, filename, url, linkMode, hasFulltext, size}]}",
         category: "retrieval",
         parameters: {
+          libraryID: { type: "number", description: "Optional target Zotero library ID. Defaults to the user library when omitted.", required: false },
           itemKey: { type: "string", description: "Unique item key", required: true }
         },
         examples: [
@@ -964,6 +966,7 @@ private getCapabilities() {
         description: "Search within fulltext content of items with context and relevance scoring",
         category: "fulltext",
         parameters: {
+          libraryID: { type: "number", description: "Optional target Zotero library ID. Defaults to the user library when omitted.", required: false },
           q: { type: "string", description: "Search query", required: true },
           itemKeys: { type: "array", items: { type: "string" }, description: "Limit search to specific items (optional)", required: false },
           contextLength: { type: "number", description: "Context length around matches (default: 200)", required: false },
@@ -980,6 +983,7 @@ private getCapabilities() {
         description: "Get the abstract/summary of a specific item",
         category: "retrieval",
         parameters: {
+          libraryID: { type: "number", description: "Optional target Zotero library ID. Defaults to the user library when omitted.", required: false },
           itemKey: { type: "string", description: "Item key", required: true },
           format: { type: "string", enum: ["json", "text"], description: "Response format (default: json)", required: false }
         }

--- a/zotero-mcp-plugin/src/modules/httpServer.ts
+++ b/zotero-mcp-plugin/src/modules/httpServer.ts
@@ -768,9 +768,12 @@ private getCapabilities() {
     tools: [
       {
         name: "get_libraries",
-        description: "List all Zotero libraries available in the current client. Returns: {libraries: [{libraryID, name, libraryType}]}",
+        description: "List all Zotero libraries available in the current client. Returns: [{libraryID, name, libraryType}]",
         category: "retrieval",
-        parameters: {}
+        parameters: {
+          limit: { type: "number", description: "Maximum results to return", required: false },
+          offset: { type: "number", description: "Pagination offset", required: false }
+        }
       },
       {
         name: "search_libraries",

--- a/zotero-mcp-plugin/src/modules/searchEngine.ts
+++ b/zotero-mcp-plugin/src/modules/searchEngine.ts
@@ -2,7 +2,7 @@ import { formatItem, formatItemBrief } from "./itemFormatter";
 
 declare let ztoolkit: ZToolkit;
 
-class MCPError extends Error {
+export class MCPError extends Error {
   status: number;
   constructor(status: number, message: string) {
     super(message);
@@ -32,7 +32,7 @@ interface SearchParams {
   offset?: string;
   sort?: string;
   direction?: string;
-  libraryID?: string; // 添加库ID参数
+  libraryID?: number; // 添加库ID参数
   includeAttachments?: string; // 是否包含附件
   includeNotes?: string; // 是否包含笔记
 
@@ -617,9 +617,7 @@ export async function handleSearchRequest(
   const startTime = Date.now();
 
   // --- 1. 参数处理和验证 ---
-  const libraryID = params.libraryID
-    ? parseInt(params.libraryID, 10)
-    : Zotero.Libraries.userLibraryID;
+  const libraryID = params.libraryID ?? Zotero.Libraries.userLibraryID;
   const limit = Math.min(parseInt(params.limit || "100", 10), 500);
   const offset = parseInt(params.offset || "0", 10);
   const sort = params.sort || "dateAdded";

--- a/zotero-mcp-plugin/src/modules/smartAnnotationExtractor.ts
+++ b/zotero-mcp-plugin/src/modules/smartAnnotationExtractor.ts
@@ -16,6 +16,7 @@ declare let Zotero: any;
 declare let ztoolkit: ZToolkit;
 
 export interface SmartAnnotationOptions {
+  libraryID?: number;
   maxTokens?: number;
   outputMode?: string; // 'smart', 'preview', 'full', 'minimal'
   types?: string[];
@@ -132,6 +133,7 @@ export class SmartAnnotationExtractor {
    * Unified annotation retrieval (replaces 4 old tools)
    */
   async getAnnotations(params: {
+    libraryID?: number;
     itemKey?: string;
     annotationId?: string;
     annotationIds?: string[];
@@ -152,6 +154,7 @@ export class SmartAnnotationExtractor {
       const effectiveSettings = MCPSettingsService.getEffectiveSettings();
       
       const options: SmartAnnotationOptions = {
+        libraryID: params.libraryID,
         maxTokens: params.maxTokens || effectiveSettings.maxTokens,
         outputMode: params.outputMode || MCPSettingsService.get('content.mode'),
         types: params.types || ['note', 'highlight', 'annotation'],
@@ -167,9 +170,9 @@ export class SmartAnnotationExtractor {
 
       // Route to different retrieval methods
       if (params.annotationId) {
-        annotations = await this.getById(params.annotationId);
+        annotations = await this.getById(params.annotationId, options.libraryID);
       } else if (params.annotationIds) {
-        annotations = await this.getByIds(params.annotationIds);
+        annotations = await this.getByIds(params.annotationIds, options.libraryID);
       } else if (params.itemKey) {
         annotations = await this.getByItem(params.itemKey, options);
       } else {
@@ -259,6 +262,7 @@ export class SmartAnnotationExtractor {
    * Intelligent search with relevance scoring
    */
   async searchAnnotations(query: string, options: {
+    libraryID?: number;
     itemKeys?: string[];
     types?: string[];
     colors?: string[];      // Filter by colors
@@ -278,6 +282,7 @@ export class SmartAnnotationExtractor {
       const hasQuery = query && query.trim().length > 0;
 
       const searchOptions: SmartAnnotationOptions = {
+        libraryID: options.libraryID,
         maxTokens: options.maxTokens || effectiveSettings.maxTokens,
         outputMode: options.outputMode || MCPSettingsService.get('content.mode'),
         types: options.types || ['note', 'highlight', 'annotation'],
@@ -293,6 +298,7 @@ export class SmartAnnotationExtractor {
       if (hasQuery) {
         // Search using AnnotationService with query
         const searchParams = {
+          libraryID: searchOptions.libraryID,
           q: query,
           itemKey: options.itemKeys?.[0], // For now, use first itemKey if provided
           type: searchOptions.types,
@@ -314,6 +320,7 @@ export class SmartAnnotationExtractor {
 
         while (hasMore) {
           const allParams = {
+            libraryID: searchOptions.libraryID,
             type: searchOptions.types,
             detailed: false,
             limit: String(batchSize),
@@ -442,16 +449,16 @@ export class SmartAnnotationExtractor {
   /**
    * Get annotation by single ID
    */
-  private async getById(annotationId: string): Promise<any[]> {
-    const annotation = await this.annotationService.getAnnotationById(annotationId);
+  private async getById(annotationId: string, libraryID?: number): Promise<any[]> {
+    const annotation = await this.annotationService.getAnnotationById(annotationId, libraryID);
     return annotation ? [annotation] : [];
   }
 
   /**
    * Get annotations by multiple IDs
    */
-  private async getByIds(annotationIds: string[]): Promise<any[]> {
-    return await this.annotationService.getAnnotationsByIds(annotationIds);
+  private async getByIds(annotationIds: string[], libraryID?: number): Promise<any[]> {
+    return await this.annotationService.getAnnotationsByIds(annotationIds, libraryID);
   }
 
   /**
@@ -463,7 +470,7 @@ export class SmartAnnotationExtractor {
     // Get notes if requested
     if (options.types!.includes('note')) {
       try {
-        const notes = await this.annotationService.getAllNotes(itemKey);
+        const notes = await this.annotationService.getAllNotes(itemKey, options.libraryID);
         annotations.push(...notes);
       } catch (error) {
         ztoolkit.log(`[SmartAnnotationExtractor] Error getting notes for ${itemKey}: ${error}`, 'warn');
@@ -474,7 +481,7 @@ export class SmartAnnotationExtractor {
     const pdfTypes = ['highlight', 'annotation', 'ink', 'text', 'image'];
     if (options.types!.some(type => pdfTypes.includes(type))) {
       try {
-        const pdfAnnotations = await this.annotationService.getPDFAnnotations(itemKey);
+        const pdfAnnotations = await this.annotationService.getPDFAnnotations(itemKey, options.libraryID);
         // Filter by requested PDF annotation types
         const filteredPdfAnnotations = pdfAnnotations.filter(ann => options.types!.includes(ann.type));
         annotations.push(...filteredPdfAnnotations);

--- a/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
+++ b/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
@@ -376,6 +376,10 @@ export class StreamableMCPServer {
         inputSchema: {
           type: 'object',
           properties: {
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
             q: { type: 'string', description: 'Search query (optional if colors or tags provided)' },
             itemKeys: {
               type: 'array',
@@ -428,6 +432,10 @@ export class StreamableMCPServer {
         inputSchema: {
           type: 'object',
           properties: {
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
             itemKey: { type: 'string', description: 'Unique item key' },
             mode: {
               type: 'string',
@@ -444,6 +452,10 @@ export class StreamableMCPServer {
         inputSchema: {
           type: 'object',
           properties: {
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
             itemKey: { type: 'string', description: 'Get all annotations for this item' },
             annotationId: { type: 'string', description: 'Get specific annotation by ID' },
             annotationIds: {
@@ -491,6 +503,10 @@ export class StreamableMCPServer {
         inputSchema: {
           type: 'object',
           properties: {
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
             itemKey: { type: 'string', description: 'Item key to get all content from this item' },
             attachmentKey: { type: 'string', description: 'Attachment key to get content from specific attachment' },
             mode: {
@@ -724,6 +740,10 @@ export class StreamableMCPServer {
         inputSchema: {
           type: 'object',
           properties: {
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
             q: { type: 'string', description: 'Search query' },
             itemKeys: { 
               type: 'array', 
@@ -748,6 +768,10 @@ export class StreamableMCPServer {
         inputSchema: {
           type: 'object',
           properties: {
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
             itemKey: { type: 'string', description: 'Item key' },
             format: {
               type: 'string',
@@ -1353,7 +1377,7 @@ export class StreamableMCPServer {
   }
 
   private async callGetItemDetails(args: any): Promise<any> {
-    const { itemKey, mode } = args;
+    const { itemKey, mode, libraryID } = args;
     
     // Import the specific handler for item details
     const { handleGetItem } = await import('./apiHandlers');
@@ -1363,6 +1387,9 @@ export class StreamableMCPServer {
     
     // Create query params with mode-based field selection
     const queryParams = new URLSearchParams();
+    if (libraryID !== undefined && libraryID !== null) {
+      queryParams.append('libraryID', String(libraryID));
+    }
     if (effectiveMode !== 'complete') {
       // Apply field filtering based on mode (this could be enhanced in apiHandlers)
       const modeConfig = this.getItemDetailsModeConfiguration(effectiveMode);
@@ -1394,7 +1421,7 @@ export class StreamableMCPServer {
   }
 
   private async callGetContent(args: any): Promise<any> {
-    const { itemKey, attachmentKey, include, format, mode, contentControl } = args;
+    const { itemKey, attachmentKey, include, format, mode, contentControl, libraryID } = args;
     const extractor = new UnifiedContentExtractor();
     
     try {
@@ -1402,10 +1429,10 @@ export class StreamableMCPServer {
       
       if (itemKey) {
         // Get content from item with unified mode control and content control parameters
-        result = await extractor.getItemContent(itemKey, include || {}, mode, contentControl);
+        result = await extractor.getItemContent(itemKey, include || {}, mode, contentControl, libraryID);
       } else if (attachmentKey) {
         // Get content from specific attachment with unified mode control and content control parameters
-        result = await extractor.getAttachmentContent(attachmentKey, mode, contentControl);
+        result = await extractor.getAttachmentContent(attachmentKey, mode, contentControl, libraryID);
       } else {
         throw new Error('Either itemKey or attachmentKey must be provided');
       }

--- a/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
+++ b/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
@@ -305,6 +305,10 @@ export class StreamableMCPServer {
         inputSchema: {
           type: 'object',
           properties: {
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
             q: { type: 'string', description: 'General search query' },
             title: { type: 'string', description: 'Title search' },
             titleOperator: {
@@ -523,11 +527,16 @@ export class StreamableMCPServer {
           description: 'Requires either itemKey or attachmentKey parameter'
         },
       },
+      {
         name: 'get_collections',
         description: 'Get collections in the library. By default returns a flat, paginated list of top-level collections. Use recursive=true to retrieve the complete nested collection tree (all levels) in one call. Use parentCollection to scope to a specific parent\'s direct children.',
         inputSchema: {
           type: 'object',
           properties: {
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
             mode: {
               type: 'string',
               enum: ['minimal', 'preview', 'standard', 'complete'],
@@ -552,6 +561,10 @@ export class StreamableMCPServer {
         inputSchema: {
           type: 'object',
           properties: {
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
             q: { type: 'string', description: 'Collection name search query' },
             limit: { type: 'number', description: 'Maximum results to return' },
           },
@@ -564,6 +577,10 @@ export class StreamableMCPServer {
           type: 'object',
           properties: {
             collectionKey: { type: 'string', description: 'Collection key' },
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
           },
           required: ['collectionKey'],
         },
@@ -575,6 +592,10 @@ export class StreamableMCPServer {
           type: 'object',
           properties: {
             collectionKey: { type: 'string', description: 'Collection key' },
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
             limit: { type: 'number', description: 'Maximum results to return' },
             offset: { type: 'number', description: 'Pagination offset' },
           },
@@ -588,6 +609,10 @@ export class StreamableMCPServer {
           type: 'object',
           properties: {
             collectionKey: { type: 'string', description: 'Parent collection key' },
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
             limit: { type: 'number', description: 'Maximum results to return (default: 100). Ignored when recursive=true.' },
             offset: { type: 'number', description: 'Pagination offset (default: 0). Ignored when recursive=true.' },
             recursive: { 
@@ -1029,7 +1054,7 @@ export class StreamableMCPServer {
           if (!args?.collectionKey) {
             throw new Error('collectionKey is required');
           }
-          result = await this.callGetCollectionDetails(args.collectionKey);
+          result = await this.callGetCollectionDetails(args);
           break;
 
         case 'get_collection_items':
@@ -1403,8 +1428,15 @@ export class StreamableMCPServer {
     return result;
   }
 
-  private async callGetCollectionDetails(collectionKey: string): Promise<any> {
-    const response = await handleGetCollectionDetails({ 1: collectionKey }, new URLSearchParams());
+  private async callGetCollectionDetails(args: any): Promise<any> {
+    const { collectionKey, ...otherArgs } = args;
+    const detailParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(otherArgs)) {
+      if (value !== undefined && value !== null) {
+        detailParams.append(key, String(value));
+      }
+    }
+    const response = await handleGetCollectionDetails({ 1: collectionKey }, detailParams);
     const result = response.body ? JSON.parse(response.body) : response;
     return result;
   }

--- a/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
+++ b/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
@@ -1,4 +1,5 @@
 import {
+  handleGetLibraries,
   handleSearch,
   handleGetItem,
   handleGetCollections,
@@ -291,6 +292,14 @@ export class StreamableMCPServer {
   private handleToolsList(request: MCPRequest): MCPResponse {
     const tools = [
       {
+        name: 'get_libraries',
+        description: 'List all Zotero libraries available in the current client. Returns minimal library metadata for each library.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+      },
+      {
         name: 'search_library',
         description: 'Search the Zotero library with advanced parameters, boolean operators, relevance scoring, and pagination. Results are from user\'s personal library. Use itemKey with get_content for full text. To find standalone PDFs without metadata, use itemType="attachment" with includeAttachments="true".',
         inputSchema: {
@@ -514,7 +523,6 @@ export class StreamableMCPServer {
           description: 'Requires either itemKey or attachmentKey parameter'
         },
       },
-      {
         name: 'get_collections',
         description: 'Get collections in the library. By default returns a flat, paginated list of top-level collections. Use recursive=true to retrieve the complete nested collection tree (all levels) in one call. Use parentCollection to scope to a specific parent\'s direct children.',
         inputSchema: {
@@ -972,6 +980,10 @@ export class StreamableMCPServer {
       let result;
       
       switch (name) {
+        case 'get_libraries':
+          result = await this.callGetLibraries();
+          break;
+
         case 'search_library':
           result = await this.callSearchLibrary(args);
           break;
@@ -1212,6 +1224,12 @@ export class StreamableMCPServer {
       return this.createError(request.id ?? null, -32603, 
         `Error executing ${name}: ${error instanceof Error ? error.message : String(error)}`);
     }
+  }
+
+  private async callGetLibraries(): Promise<any> {
+    const response = await handleGetLibraries();
+    const result = response.body ? JSON.parse(response.body) : response;
+    return result;
   }
 
   private async callSearchLibrary(args: any): Promise<any> {
@@ -2480,6 +2498,7 @@ export class StreamableMCPServer {
         'ping'
       ],
       availableTools: [
+        'get_libraries',
         'search_library',
         'search_annotations',
         'get_item_details',

--- a/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
+++ b/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
@@ -662,6 +662,10 @@ export class StreamableMCPServer {
         inputSchema: {
           type: 'object',
           properties: {
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
             name: { type: 'string', description: 'Name of the new collection' },
             parentCollection: {
               type: 'string',
@@ -677,6 +681,10 @@ export class StreamableMCPServer {
         inputSchema: {
           type: 'object',
           properties: {
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
             collectionKey: { type: 'string', description: 'Key of the collection to update' },
             name: { type: 'string', description: 'New name for the collection' },
             parentCollection: {
@@ -693,6 +701,10 @@ export class StreamableMCPServer {
         inputSchema: {
           type: 'object',
           properties: {
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
             collectionKey: { type: 'string', description: 'Key of the collection to delete' },
             deleteItems: {
               type: 'boolean',
@@ -708,6 +720,10 @@ export class StreamableMCPServer {
         inputSchema: {
           type: 'object',
           properties: {
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
             collectionKey: { type: 'string', description: 'Key of the target collection' },
             itemKeys: {
               type: 'array',
@@ -724,6 +740,10 @@ export class StreamableMCPServer {
         inputSchema: {
           type: 'object',
           properties: {
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
             collectionKey: { type: 'string', description: 'Key of the collection' },
             itemKeys: {
               type: 'array',
@@ -880,6 +900,10 @@ export class StreamableMCPServer {
         inputSchema: {
           type: 'object',
           properties: {
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
             action: {
               type: 'string',
               enum: ['create', 'update', 'append'],
@@ -912,6 +936,10 @@ export class StreamableMCPServer {
         inputSchema: {
           type: 'object',
           properties: {
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
             action: {
               type: 'string',
               enum: ['add', 'remove', 'set'],
@@ -936,6 +964,10 @@ export class StreamableMCPServer {
         inputSchema: {
           type: 'object',
           properties: {
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
             itemKey: {
               type: 'string',
               description: 'Item key to update metadata on'
@@ -972,6 +1004,10 @@ export class StreamableMCPServer {
         inputSchema: {
           type: 'object',
           properties: {
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
             action: {
               type: 'string',
               enum: ['create', 'reparent'],
@@ -1539,6 +1575,7 @@ export class StreamableMCPServer {
 
   private async callCreateCollection(args: any): Promise<any> {
     const response = await handleCreateCollection({
+      libraryID: args.libraryID,
       name: args.name,
       parentCollection: args.parentCollection,
     });
@@ -1558,14 +1595,14 @@ export class StreamableMCPServer {
   }
 
   private async callAddItemsToCollection(args: any): Promise<any> {
-    const { collectionKey, itemKeys } = args;
-    const response = await handleAddItemsToCollection({ 1: collectionKey }, { itemKeys });
+    const { collectionKey, itemKeys, libraryID } = args;
+    const response = await handleAddItemsToCollection({ 1: collectionKey }, { itemKeys, libraryID });
     return response.body ? JSON.parse(response.body) : response;
   }
 
   private async callRemoveItemsFromCollection(args: any): Promise<any> {
-    const { collectionKey, itemKeys } = args;
-    const response = await handleRemoveItemsFromCollection({ 1: collectionKey }, { itemKeys });
+    const { collectionKey, itemKeys, libraryID } = args;
+    const response = await handleRemoveItemsFromCollection({ 1: collectionKey }, { itemKeys, libraryID });
     return response.body ? JSON.parse(response.body) : response;
   }
 
@@ -1921,7 +1958,7 @@ export class StreamableMCPServer {
    * Handle write_note tool calls: create, update, append notes
    */
   private async callWriteNote(args: any): Promise<any> {
-    const { action, parentKey, noteKey, content, tags } = args;
+    const { action, parentKey, noteKey, content, tags, libraryID = Zotero.Libraries.userLibraryID } = args;
 
     try {
       const htmlContent = this.markdownToNoteHtml(content);
@@ -1929,14 +1966,14 @@ export class StreamableMCPServer {
       switch (action) {
         case 'create': {
           const note = new Zotero.Item('note');
-          note.libraryID = Zotero.Libraries.userLibraryID;
+          note.libraryID = libraryID;
 
           if (parentKey) {
             const parentItem = Zotero.Items.getByLibraryAndKey(
-              Zotero.Libraries.userLibraryID, parentKey
+              libraryID, parentKey
             );
             if (!parentItem) {
-              throw new Error(`Parent item not found: ${parentKey}`);
+              throw new Error(`Parent item not found in library ${libraryID}: ${parentKey}`);
             }
             if (parentItem.isNote()) {
               throw new Error('Cannot attach a note to another note');
@@ -1984,10 +2021,10 @@ export class StreamableMCPServer {
           }
 
           const existingNote = Zotero.Items.getByLibraryAndKey(
-            Zotero.Libraries.userLibraryID, noteKey
+            libraryID, noteKey
           );
           if (!existingNote) {
-            throw new Error(`Note not found: ${noteKey}`);
+            throw new Error(`Note not found in library ${libraryID}: ${noteKey}`);
           }
           if (!existingNote.isNote()) {
             throw new Error(`Item ${noteKey} is not a note`);
@@ -2028,10 +2065,10 @@ export class StreamableMCPServer {
           }
 
           const existingNote = Zotero.Items.getByLibraryAndKey(
-            Zotero.Libraries.userLibraryID, noteKey
+            libraryID, noteKey
           );
           if (!existingNote) {
-            throw new Error(`Note not found: ${noteKey}`);
+            throw new Error(`Note not found in library ${libraryID}: ${noteKey}`);
           }
           if (!existingNote.isNote()) {
             throw new Error(`Item ${noteKey} is not a note`);
@@ -2085,14 +2122,14 @@ export class StreamableMCPServer {
    * Handle write_tag tool calls: add, remove, set tags on items
    */
   private async callWriteTag(args: any): Promise<any> {
-    const { action, itemKey, tags } = args;
+    const { action, itemKey, tags, libraryID = Zotero.Libraries.userLibraryID } = args;
 
     try {
       const item = Zotero.Items.getByLibraryAndKey(
-        Zotero.Libraries.userLibraryID, itemKey
+        libraryID, itemKey
       );
       if (!item) {
-        throw new Error(`Item not found: ${itemKey}`);
+        throw new Error(`Item not found in library ${libraryID}: ${itemKey}`);
       }
 
       const beforeTags = item.getTags().map((t: any) => t.tag);
@@ -2161,14 +2198,14 @@ export class StreamableMCPServer {
    * Handle write_metadata tool calls: update fields and creators on items
    */
   private async callWriteMetadata(args: any): Promise<any> {
-    const { itemKey, fields, creators } = args;
+    const { itemKey, fields, creators, libraryID = Zotero.Libraries.userLibraryID } = args;
 
     try {
       const item = Zotero.Items.getByLibraryAndKey(
-        Zotero.Libraries.userLibraryID, itemKey
+        libraryID, itemKey
       );
       if (!item) {
-        throw new Error(`Item not found: ${itemKey}`);
+        throw new Error(`Item not found in library ${libraryID}: ${itemKey}`);
       }
       if (!item.isRegularItem()) {
         throw new Error(`Item ${itemKey} is not a regular item (it is a ${item.itemType}). Use write_note for notes.`);
@@ -2248,7 +2285,7 @@ export class StreamableMCPServer {
    * Handle write_item tool calls: create items and reparent attachments
    */
   private async callWriteItem(args: any): Promise<any> {
-    const { action, itemType, fields, creators, tags, attachmentKeys, parentKey } = args;
+    const { action, itemType, fields, creators, tags, attachmentKeys, parentKey, libraryID = Zotero.Libraries.userLibraryID } = args;
 
     try {
       switch (action) {
@@ -2259,7 +2296,7 @@ export class StreamableMCPServer {
 
           // Create new item
           const item = new Zotero.Item(itemType);
-          item.libraryID = Zotero.Libraries.userLibraryID;
+          item.libraryID = libraryID;
 
           // Set fields
           if (fields && typeof fields === 'object') {
@@ -2302,14 +2339,14 @@ export class StreamableMCPServer {
           if (attachmentKeys && Array.isArray(attachmentKeys)) {
             for (const attKey of attachmentKeys) {
               const attachment = Zotero.Items.getByLibraryAndKey(
-                Zotero.Libraries.userLibraryID, attKey
+                libraryID, attKey
               );
               if (!attachment) {
-                ztoolkit.log(`[StreamableMCP] Attachment not found: ${attKey}`, 'warn');
+                ztoolkit.log(`[StreamableMCP] Attachment not found in library ${libraryID}: ${attKey}`, 'warn');
                 continue;
               }
               if (!attachment.isAttachment()) {
-                ztoolkit.log(`[StreamableMCP] Item ${attKey} is not an attachment, skipping`, 'warn');
+                ztoolkit.log(`[StreamableMCP] Item ${attKey} is not an attachment (type: ${attachment.itemType}), skipping`, 'warn');
                 continue;
               }
               attachment.parentKey = item.key;
@@ -2348,10 +2385,10 @@ export class StreamableMCPServer {
 
           // Verify parent exists
           const parentItem = Zotero.Items.getByLibraryAndKey(
-            Zotero.Libraries.userLibraryID, parentKey
+            libraryID, parentKey
           );
           if (!parentItem) {
-            throw new Error(`Parent item not found: ${parentKey}`);
+            throw new Error(`Parent item not found in library ${libraryID}: ${parentKey}`);
           }
           if (!parentItem.isRegularItem()) {
             throw new Error(`Parent ${parentKey} is not a regular item (type: ${parentItem.itemType})`);
@@ -2361,10 +2398,10 @@ export class StreamableMCPServer {
           for (const attKey of attachmentKeys) {
             try {
               const attachment = Zotero.Items.getByLibraryAndKey(
-                Zotero.Libraries.userLibraryID, attKey
+                libraryID, attKey
               );
               if (!attachment) {
-                results.push({ key: attKey, success: false, error: 'Not found' });
+                results.push({ key: attKey, success: false, error: `Not found in library ${libraryID}` });
                 continue;
               }
               if (!attachment.isAttachment() && !attachment.isNote()) {

--- a/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
+++ b/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
@@ -1,5 +1,6 @@
 import {
   handleGetLibraries,
+  handleSearchLibraries,
   handleSearch,
   handleGetItem,
   handleGetCollections,
@@ -351,6 +352,19 @@ export class StreamableMCPServer {
             limit: { type: 'number', description: 'Maximum results to return (overrides mode default)' },
             offset: { type: 'number', description: 'Pagination offset' },
           },
+        },
+      },
+      {
+        name: 'search_libraries',
+        description: 'Search libraries by name',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            q: { type: 'string', description: 'Library name search query' },
+            limit: { type: 'number', description: 'Maximum results to return' },
+            offset: { type: 'number', description: 'Pagination offset' },
+          },
+          required: ['q'],
         },
       },
       {
@@ -1009,6 +1023,13 @@ export class StreamableMCPServer {
           result = await this.callGetLibraries();
           break;
 
+        case 'search_libraries':
+          if (!args?.q) {
+            throw new Error('q is required');
+          }
+          result = await this.callSearchLibraries(args);
+          break;
+
         case 'search_library':
           result = await this.callSearchLibrary(args);
           break;
@@ -1253,6 +1274,18 @@ export class StreamableMCPServer {
 
   private async callGetLibraries(): Promise<any> {
     const response = await handleGetLibraries();
+    const result = response.body ? JSON.parse(response.body) : response;
+    return result;
+  }
+
+  private async callSearchLibraries(args: any): Promise<any> {
+    const searchParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(args || {})) {
+      if (value !== undefined && value !== null) {
+        searchParams.append(key, String(value));
+      }
+    }
+    const response = await handleSearchLibraries(searchParams);
     const result = response.body ? JSON.parse(response.body) : response;
     return result;
   }
@@ -2531,6 +2564,7 @@ export class StreamableMCPServer {
       ],
       availableTools: [
         'get_libraries',
+        'search_libraries',
         'search_library',
         'search_annotations',
         'get_item_details',

--- a/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
+++ b/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
@@ -294,10 +294,13 @@ export class StreamableMCPServer {
     const tools = [
       {
         name: 'get_libraries',
-        description: 'List all Zotero libraries available in the current client. Returns minimal library metadata for each library.',
+        description: 'List all Zotero libraries available in the current client. Returns minimal library metadata for each library as a paginated array.',
         inputSchema: {
           type: 'object',
-          properties: {},
+          properties: {
+            limit: { type: 'number', description: 'Maximum results to return' },
+            offset: { type: 'number', description: 'Pagination offset' },
+          },
         },
       },
       {
@@ -1020,7 +1023,7 @@ export class StreamableMCPServer {
       
       switch (name) {
         case 'get_libraries':
-          result = await this.callGetLibraries();
+          result = await this.callGetLibraries(args);
           break;
 
         case 'search_libraries':
@@ -1272,8 +1275,15 @@ export class StreamableMCPServer {
     }
   }
 
-  private async callGetLibraries(): Promise<any> {
-    const response = await handleGetLibraries();
+  private async callGetLibraries(args: any): Promise<any> {
+    const queryParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(args || {})) {
+      if (value !== undefined && value !== null) {
+        queryParams.append(key, String(value));
+      }
+    }
+
+    const response = await handleGetLibraries(queryParams);
     const result = response.body ? JSON.parse(response.body) : response;
     return result;
   }

--- a/zotero-mcp-plugin/src/modules/unifiedContentExtractor.ts
+++ b/zotero-mcp-plugin/src/modules/unifiedContentExtractor.ts
@@ -56,9 +56,10 @@ export class UnifiedContentExtractor {
   /**
    * Extract content from an item with mode control and intelligent processing
    */
-  async getItemContent(itemKey: string, include: ContentIncludeOptions = {}, mode?: string, contentControl?: ContentControl): Promise<ContentResult> {
+  async getItemContent(itemKey: string, include: ContentIncludeOptions = {}, mode?: string, contentControl?: ContentControl, libraryID?: number): Promise<ContentResult> {
     try {
-      const item = Zotero.Items.getByLibraryAndKey(Zotero.Libraries.userLibraryID, itemKey);
+      const targetLibraryID = libraryID ?? Zotero.Libraries.userLibraryID;
+      const item = Zotero.Items.getByLibraryAndKey(targetLibraryID, itemKey);
       if (!item) {
         throw new Error(`Item with key ${itemKey} not found`);
       }
@@ -155,9 +156,10 @@ export class UnifiedContentExtractor {
   /**
    * Extract content from a specific attachment with mode control (replaces get_attachment_content)
    */
-  async getAttachmentContent(attachmentKey: string, mode?: string, contentControl?: ContentControl): Promise<any> {
+  async getAttachmentContent(attachmentKey: string, mode?: string, contentControl?: ContentControl, libraryID?: number): Promise<any> {
     try {
-      const attachment = Zotero.Items.getByLibraryAndKey(Zotero.Libraries.userLibraryID, attachmentKey);
+      const targetLibraryID = libraryID ?? Zotero.Libraries.userLibraryID;
+      const attachment = Zotero.Items.getByLibraryAndKey(targetLibraryID, attachmentKey);
       if (!attachment?.isAttachment()) {
         throw new Error(`Attachment with key ${attachmentKey} not found`);
       }

--- a/zotero-mcp-plugin/src/modules/unifiedContentExtractor.ts
+++ b/zotero-mcp-plugin/src/modules/unifiedContentExtractor.ts
@@ -56,10 +56,15 @@ export class UnifiedContentExtractor {
   /**
    * Extract content from an item with mode control and intelligent processing
    */
-  async getItemContent(itemKey: string, include: ContentIncludeOptions = {}, mode?: string, contentControl?: ContentControl, libraryID?: number): Promise<ContentResult> {
+  async getItemContent(
+    itemKey: string,
+    include: ContentIncludeOptions = {},
+    mode?: string,
+    contentControl?: ContentControl,
+    libraryID: number = Zotero.Libraries.userLibraryID,
+  ): Promise<ContentResult> {
     try {
-      const targetLibraryID = libraryID ?? Zotero.Libraries.userLibraryID;
-      const item = Zotero.Items.getByLibraryAndKey(targetLibraryID, itemKey);
+      const item = Zotero.Items.getByLibraryAndKey(libraryID, itemKey);
       if (!item) {
         throw new Error(`Item with key ${itemKey} not found`);
       }
@@ -156,10 +161,14 @@ export class UnifiedContentExtractor {
   /**
    * Extract content from a specific attachment with mode control (replaces get_attachment_content)
    */
-  async getAttachmentContent(attachmentKey: string, mode?: string, contentControl?: ContentControl, libraryID?: number): Promise<any> {
+  async getAttachmentContent(
+    attachmentKey: string,
+    mode?: string,
+    contentControl?: ContentControl,
+    libraryID: number = Zotero.Libraries.userLibraryID,
+  ): Promise<any> {
     try {
-      const targetLibraryID = libraryID ?? Zotero.Libraries.userLibraryID;
-      const attachment = Zotero.Items.getByLibraryAndKey(targetLibraryID, attachmentKey);
+      const attachment = Zotero.Items.getByLibraryAndKey(libraryID, attachmentKey);
       if (!attachment?.isAttachment()) {
         throw new Error(`Attachment with key ${attachmentKey} not found`);
       }


### PR DESCRIPTION
## Summary / 摘要

This PR adds multi-library support to existing MCP operations by allowing them to accept an optional `libraryID`.

为现有 MCP 操作补充了多文库支持，使其可以接收可选的 `libraryID` 参数。

Before this change, these operations only worked against the personal library. With this PR, MCP clients can first list the available libraries and then explicitly target a specific library, while preserving the existing default behavior when `libraryID` is omitted.

在此之前，这些操作只能作用于个人文库。现在 MCP 客户端可以先获取当前可用的 libraries，再显式指定目标 library；同时在未传入 `libraryID` 时，仍保持原有默认行为不变。

## Changes / 变更内容

- Added `get_libraries` to list available Zotero libraries  
  新增 `get_libraries`，用于列出当前可用的文库

- Added `search_libraries` to search libraries by name  
  新增 `search_libraries`，用于按名称搜索文库

- Added optional `libraryID` support to existing retrieval and search tools, including:  
  为现有检索和搜索工具增加了可选的 `libraryID` 支持，包括：
  - `search_library`
  - `get_item_details`
  - `get_content`
  - `search_annotations`
  - `get_collections`
  - `search_collections`
  - `get_collection_details`
  - `get_collection_items`
  - `get_subcollections`
  - `search_fulltext`
  - `get_item_abstract`

- Added optional `libraryID` support to collection write operations:  
  为 collection 相关写操作增加了可选的 `libraryID` 支持：
  - `create_collection`
  - `update_collection`
  - `delete_collection`
  - `add_items_to_collection`
  - `remove_items_from_collection`

- Added optional `libraryID` support to MCP write operations:  
  为 MCP 写入操作增加了可选的 `libraryID` 支持：
  - `write_item`
  - `write_note`
  - `write_tag`
  - `write_metadata`

## Validation / 验证

- Ran `npm run build` successfully  
  执行 `npm run build`，构建通过

- Verified in Codex that when `libraryID` is omitted, existing behavior remains unchanged and operations still default to the personal library  
  在 Codex 中验证了未传入 `libraryID` 时，现有行为保持不变，仍默认对个人文库执行操作

- Validated each MCP interface updated in this PR with an explicit `libraryID`  
  对这次改动涉及的每个 MCP 接口都进行了验证，确认显式传入 `libraryID` 时行为正确

- Verified that invalid `libraryID` input returns an error  
  验证了传入无效 `libraryID` 时会正确返回错误

## Notes / 说明

- `semantic_search` and `find_similar` are not changed in this PR, because supporting multi-library behavior for them would require changes to the semantic index format, which would invalidate indexes created by previous versions.  
  `semantic_search` 和 `find_similar` 暂未改动，因为要支持多文库，需要调整语义索引格式，这会导致之前版本建立的索引失效。
