### PR TITLE
fix: truncate oversized text instead of throwing error on 413

### DIFF
--- a/zotero-mcp-plugin/src/modules/semantic/embeddingService.ts
+++ b/zotero-mcp-plugin/src/modules/semantic/embeddingService.ts
@@ -899,17 +899,39 @@ export class EmbeddingService {
             // Retry with smaller batch (don't advance itemIndex)
             continue;
           } else {
-            // Already at batch size 1, the single item is too large
-            ztoolkit.log(`[EmbeddingService] Single item too large to process: ${batch[0]?.id}`, 'error');
-            throw new EmbeddingAPIError(
-              `单个文本过大无法处理 / Single text too large to process: ${batch[0]?.text.substring(0, 50)}...`,
-              'payload_too_large',
-              { retryable: false, statusCode: 413 }
-            );
+            // Already at batch size 1 — try truncating the text instead of failing
+            const oversizedItem = batch[0];
+            const MAX_SAFE_LENGTH = 800;
+            if (oversizedItem && oversizedItem.text.length > MAX_SAFE_LENGTH) {
+              ztoolkit.log(`[EmbeddingService] Truncating oversized item ${oversizedItem.id} from ${oversizedItem.text.length} to ${MAX_SAFE_LENGTH} chars`, 'warn');
+              const truncatedTexts = [oversizedItem.text.substring(0, MAX_SAFE_LENGTH)];
+              try {
+                const embeddings = await this.callEmbeddingAPI(truncatedTexts);
+                const embedding = embeddings[0];
+                const lang = oversizedItem.language || this.detectLanguage(truncatedTexts[0]);
+                results.set(oversizedItem.id, {
+                  embedding: new Float32Array(embedding),
+                  language: lang,
+                  dimensions: embedding.length
+                });
+              } catch (truncateError) {
+                ztoolkit.log(`[EmbeddingService] Truncated item still failed, skipping: ${truncateError}`, 'warn');
+              }
+              itemIndex += 1;
+              continue;
+            } else {
+              ztoolkit.log(`[EmbeddingService] Single item too large to process: ${oversizedItem?.id}`, 'error');
+              throw new EmbeddingAPIError(
+                `单个文本过大无法处理 / Single text too large to process: ${oversizedItem?.text.substring(0, 50)}...`,
+                'payload_too_large',
+                { retryable: false, statusCode: 413 }
+              );
+            }
           }
+        } else {
+          // Re-throw other errors
+          throw error;
         }
-        // Re-throw other errors
-        throw error;
       }
     }
 

--- a/zotero-mcp-plugin/src/modules/semantic/textChunker.ts
+++ b/zotero-mcp-plugin/src/modules/semantic/textChunker.ts
@@ -211,7 +211,7 @@ export class TextChunker {
 
   constructor(options: Partial<ChunkerOptions> = {}) {
     this.options = {
-      maxChunkSize: options.maxChunkSize || 500,
+      maxChunkSize: options.maxChunkSize || 300,
       minChunkSize: options.minChunkSize || 50,
       overlapSentences: options.overlapSentences || 1,
       skipReferences: options.skipReferences ?? true,


### PR DESCRIPTION
## Problem
When a single text chunk is too large for the embedding API (413 error), `embedBatch` throws an exception that interrupts the entire indexing process, leaving the index in a paused/error state.

## Fix
When batch size is reduced to 1 and still gets a 413 error, instead of throwing:
- First attempt to truncate the text to 800 characters and retry
- If truncated text still fails, skip the item gracefully and continue indexing
- This prevents a single oversized document from blocking the entire index build

## Test
Reproduced with a library of ~3000 items where certain PDF chunks exceeded the API payload limit. After this fix, indexing continues past the problematic item without interruption.