### PR TITLE
Fix Windows mojibake in MCP collection responses

### DIFF
--- a/zotero-mcp-plugin/src/modules/apiHandlers.ts
+++ b/zotero-mcp-plugin/src/modules/apiHandlers.ts
@@ -10,6 +10,7 @@ import {
   formatCollectionList,
   formatCollectionDetails,
   formatCollectionTree,
+  getCollectionName,
 } from "./collectionFormatter";
 import { handleSearchRequest } from "./searchEngine";
 import { FulltextService } from "./fulltextService";
@@ -229,8 +230,8 @@ export async function handleGetCollections(
 
     // Sorting
     collections.sort((a: any, b: any) => {
-      const aVal = a[sort] || "";
-      const bVal = b[sort] || "";
+      const aVal = sort === "name" ? getCollectionName(a) : (a[sort] || "");
+      const bVal = sort === "name" ? getCollectionName(b) : (b[sort] || "");
       if (aVal < bVal) return direction === "asc" ? -1 : 1;
       if (aVal > bVal) return direction === "asc" ? 1 : -1;
       return 0;
@@ -303,7 +304,7 @@ export async function handleSearchCollections(
 
     const matchedCollections = allCollections.filter(
       (collection: Zotero.Collection) =>
-        collection.name.toLowerCase().includes(lowerCaseQuery),
+        getCollectionName(collection).toLowerCase().includes(lowerCaseQuery),
     );
 
     const collections = matchedCollections;

--- a/zotero-mcp-plugin/src/modules/collectionFormatter.ts
+++ b/zotero-mcp-plugin/src/modules/collectionFormatter.ts
@@ -3,6 +3,30 @@ import { formatItem, formatItems } from "./itemFormatter";
 declare let Zotero: any;
 
 /**
+ * Safely read collection name as a JS Unicode string.
+ * Prefer Zotero's JSON serialization path when available.
+ */
+export function getCollectionName(collection: Zotero.Collection): string {
+  if (!collection) {
+    return "";
+  }
+
+  try {
+    if (typeof (collection as any).toJSON === "function") {
+      const json = (collection as any).toJSON();
+      if (json && typeof json.name === "string") {
+        return json.name;
+      }
+    }
+  } catch {
+    // Fall through to direct property access.
+  }
+
+  const name = (collection as any).name;
+  return name === null || name === undefined ? "" : String(name);
+}
+
+/**
  * Get the full hierarchical path of a collection
  * @param collection - The Zotero.Collection object
  * @returns Full path like "Parent > Child > Grandchild"
@@ -12,7 +36,7 @@ export function getCollectionPath(collection: Zotero.Collection): string {
   let current: Zotero.Collection | null = collection;
 
   while (current) {
-    pathParts.unshift(current.name);
+    pathParts.unshift(getCollectionName(current));
     if (current.parentKey) {
       current = Zotero.Collections.getByLibraryAndKey(
         current.libraryID,
@@ -59,7 +83,7 @@ export function formatCollection(collection: Zotero.Collection) {
     key: collection.key,
     version: collection.version,
     libraryID: collection.libraryID,
-    name: collection.name,
+    name: getCollectionName(collection),
     path: getCollectionPath(collection),
     depth: getCollectionDepth(collection),
     parentCollection: collection.parentKey,
@@ -78,7 +102,7 @@ export function formatCollectionBrief(collection: Zotero.Collection) {
   }
   return {
     key: collection.key,
-    name: collection.name,
+    name: getCollectionName(collection),
     path: getCollectionPath(collection),
     depth: getCollectionDepth(collection),
     parentCollection: collection.parentKey,

--- a/zotero-mcp-plugin/src/modules/httpServer.ts
+++ b/zotero-mcp-plugin/src/modules/httpServer.ts
@@ -29,6 +29,53 @@ function getByteLength(str: string): number {
 }
 
 /**
+ * Slice string by UTF-8 byte length without splitting multibyte characters.
+ */
+function sliceByUtf8Bytes(str: string, maxBytes: number): string {
+  if (maxBytes <= 0 || !str) {
+    return "";
+  }
+
+  let bytes = 0;
+  let end = 0;
+
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i);
+    let charBytes = 0;
+
+    if (code < 0x80) {
+      charBytes = 1;
+    } else if (code < 0x800) {
+      charBytes = 2;
+    } else if (code >= 0xd800 && code <= 0xdbff && i + 1 < str.length) {
+      const next = str.charCodeAt(i + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        charBytes = 4;
+      } else {
+        charBytes = 3;
+      }
+    } else {
+      charBytes = 3;
+    }
+
+    if (bytes + charBytes > maxBytes) {
+      break;
+    }
+
+    bytes += charBytes;
+    end = i + 1;
+
+    // Skip low surrogate after consuming a valid pair.
+    if (charBytes === 4) {
+      i++;
+      end = i + 1;
+    }
+  }
+
+  return str.substring(0, end);
+}
+
+/**
  * Write string to output stream with correct UTF-8 encoding
  */
 function writeStringToStream(output: any, str: string): void {
@@ -346,13 +393,14 @@ export class HttpServer {
           // Step 2: Read body based on Content-Length (for POST requests)
           if (headersComplete && contentLength > 0) {
             const bodyStart = bodyStartIndex + 4; // Skip \r\n\r\n
-            const currentBodyLength = requestText.length - bodyStart;
-            const remainingBodyBytes = contentLength - currentBodyLength;
+            const getCurrentBodyBytes = () => getByteLength(requestText.substring(bodyStart));
+            const currentBodyBytes = getCurrentBodyBytes();
+            const remainingBodyBytes = contentLength - currentBodyBytes;
 
-            ztoolkit.log(`[HttpServer] Reading body: Content-Length=${contentLength}, current=${currentBodyLength}, remaining=${remainingBodyBytes}`);
+            ztoolkit.log(`[HttpServer] Reading body: Content-Length=${contentLength}, current=${currentBodyBytes}, remaining=${remainingBodyBytes}`);
 
             waitAttempts = 0; // Reset wait counter for body reading
-            while (remainingBodyBytes > 0 && (requestText.length - bodyStart) < contentLength) {
+            while (getCurrentBodyBytes() < contentLength) {
               const available = input.available();
 
               if (available === 0) {
@@ -365,7 +413,7 @@ export class HttpServer {
                 continue;
               }
 
-              const bytesToRead = Math.min(8192, contentLength - (requestText.length - bodyStart), available);
+              const bytesToRead = Math.min(8192, contentLength - getCurrentBodyBytes(), available);
               let chunk = "";
               try {
                 const str: { value?: string } = {};
@@ -378,7 +426,7 @@ export class HttpServer {
               }
 
               requestText += chunk;
-              totalBytesRead += chunk.length;
+              totalBytesRead += getByteLength(chunk);
             }
           }
         } catch (readError) {
@@ -464,10 +512,11 @@ export class HttpServer {
               // Only consume the current request body. Extra bytes may belong to
               // a pipelined next request on the same socket.
               if (contentLength > 0) {
-                requestBody = rawBody.substring(0, contentLength);
-                if (rawBody.length > contentLength) {
+                requestBody = sliceByUtf8Bytes(rawBody, contentLength);
+                const rawBodyBytes = getByteLength(rawBody);
+                if (rawBodyBytes > contentLength) {
                   ztoolkit.log(
-                    `[HttpServer] Detected trailing bytes after request body (${rawBody.length - contentLength} bytes), ignoring extra data for this request`,
+                    `[HttpServer] Detected trailing bytes after request body (${rawBodyBytes - contentLength} bytes), ignoring extra data for this request`,
                     "warn",
                   );
                 }


### PR DESCRIPTION
## Summary
This PR fixes Unicode/mojibake issues observed on Windows in MCP tool responses, especially for `get_collections` (`name`/`path`) while keeping `get_item_details` behavior intact.

## Root Cause
There were two divergent paths:
1. HTTP request-body handling mixed byte-length (`Content-Length`) and JS string-length semantics, which can break multibyte boundaries.
2. Collections formatting used direct `collection.name` access everywhere, while item details used a safer string extraction path.

## Changes
- `src/modules/httpServer.ts`
  - Add `sliceByUtf8Bytes()` and use UTF-8 byte-aware body slicing.
  - Use UTF-8 byte length checks during body read loop and logging.
- `src/modules/collectionFormatter.ts`
  - Add `getCollectionName()` helper (prefer `collection.toJSON().name`, fallback to safe string conversion).
  - Use helper in collection `name` output and `path` construction.
- `src/modules/apiHandlers.ts`
  - Reuse `getCollectionName()` for collection sorting and search matching.

## Validation
- `tools/call` -> `get_collections` with `recursive: true`
  - Chinese names/path display correctly (e.g. `人工智能`, `教材`).
  - No replacement char `�` in `result.content[0].text`.
- Regression: `tools/call` -> `get_item_details`
  - Chinese notes/file names remain correct.

## Scope
- No endpoint/protocol changes.
- No unrelated refactors.
- Cross-platform compatible (Windows/macOS/Linux).