### PR TITLE
Update clientConfigGenerators.ts to facilitate usage of MCP in Chatbox

### DIFF
--- a/zotero-mcp-plugin/src/modules/clientConfigGenerator.ts
+++ b/zotero-mcp-plugin/src/modules/clientConfigGenerator.ts
@@ -200,9 +200,8 @@ url = "http://127.0.0.1:${port}/mcp"
       configTemplate: (port: number, serverName = "zotero-mcp") => ({
         mcpServers: {
           [serverName]: {
-            command: "npx",
-            args: ["mcp-remote", `http://127.0.0.1:${port}/mcp`],
-            env: {}
+            url: `http://127.0.0.1:${port}/mcp`,
+            transport: "http"
           }
         }
       }),


### PR DESCRIPTION
更改了为 Chatbox 导出 JSON 文件的生成方式，以便直接使 Chatbox 调用 zotero-MCP 插件提供的 MCP 