### PR TITLE
feat: write_item 新增 import action — 支持将本地文件导入为 Zotero 附件

### DIFF
--- a/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
+++ b/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
@@ -894,14 +894,14 @@ export class StreamableMCPServer {
       },
       {
         name: 'write_item',
-        description: 'Create a new Zotero item or re-parent existing attachments. Common workflow: read PDF → extract metadata → create item → attach PDF via attachmentKeys. Confirm with user before executing.',
+        description: 'Create a new Zotero item, re-parent existing attachments, or import a local file as an attachment. Common workflows: (1) read PDF → extract metadata → create item → attach PDF via attachmentKeys; (2) convert PDF to Markdown → import the .md file as attachment via import action. Confirm with user before executing.',
         inputSchema: {
           type: 'object',
           properties: {
             action: {
               type: 'string',
-              enum: ['create', 'reparent'],
-              description: 'create: create a new item with metadata. reparent: move an attachment under a different parent item.'
+              enum: ['create', 'reparent', 'import'],
+              description: 'create: create a new item with metadata. reparent: move an attachment under a different parent item. import: import a local file (e.g., Markdown, PDF) as an attachment to an existing item.'
             },
             itemType: {
               type: 'string',
@@ -939,6 +939,14 @@ export class StreamableMCPServer {
             parentKey: {
               type: 'string',
               description: 'For reparent action: the target parent item key to move attachments to'
+            },
+            filePath: {
+              type: 'string',
+              description: 'For import action: absolute path to the file to import as an attachment'
+            },
+            parentItemKey: {
+              type: 'string',
+              description: 'For import action: Zotero item key of the parent to attach the file to'
             }
           },
           required: ['action']
@@ -2125,10 +2133,10 @@ export class StreamableMCPServer {
   }
 
   /**
-   * Handle write_item tool calls: create items and reparent attachments
+   * Handle write_item tool calls: create items, reparent attachments, and import files
    */
   private async callWriteItem(args: any): Promise<any> {
-    const { action, itemType, fields, creators, tags, attachmentKeys, parentKey } = args;
+    const { action, itemType, fields, creators, tags, attachmentKeys, parentKey, filePath, parentItemKey, title } = args;
 
     try {
       switch (action) {
@@ -2278,8 +2286,52 @@ export class StreamableMCPServer {
           };
         }
 
+        case 'import': {
+          if (!filePath || typeof filePath !== 'string') {
+            throw new Error('filePath is required for import action (absolute path to the file)');
+          }
+          if (!parentItemKey) {
+            throw new Error('parentItemKey is required for import action');
+          }
+
+          // Verify parent exists
+          const parentItem = Zotero.Items.getByLibraryAndKey(
+            Zotero.Libraries.userLibraryID, parentItemKey
+          );
+          if (!parentItem) {
+            throw new Error(`Parent item not found: ${parentItemKey}`);
+          }
+          if (!parentItem.isRegularItem()) {
+            throw new Error(`Parent ${parentItemKey} is not a regular item (type: ${parentItem.itemType}), cannot attach files`);
+          }
+
+          // Import file as attachment
+          const attachment = await Zotero.Attachments.importFromFile({
+            file: filePath,
+            parentItemID: parentItem.id,
+            title: title || filePath.split(/[\\/]/).pop() || 'Imported Attachment'
+          });
+
+          ztoolkit.log(`[StreamableMCP] Imported file as attachment ${attachment.key} under ${parentItemKey}`);
+
+          return {
+            action: 'import',
+            success: true,
+            data: {
+              attachmentKey: attachment.key,
+              parentItemKey,
+              filePath,
+              title: attachment.getField('title')
+            },
+            metadata: {
+              extractedAt: new Date().toISOString(),
+              message: `File imported as attachment (key: ${attachment.key}) under parent ${parentItemKey}`
+            }
+          };
+        }
+
         default:
-          throw new Error(`Unknown action: ${action}. Use create or reparent.`);
+          throw new Error(`Unknown action: ${action}. Use create, reparent, or import.`);
       }
     } catch (error) {
       ztoolkit.log(`[StreamableMCP] Write item error: ${error}`, 'error');


### PR DESCRIPTION
## 概述

为 `write_item` 工具新增 `import` action，使 AI 助手能够将本地文件（如 MinerU 转换的 Markdown、PDF 等）自动导入为 Zotero 条目的附件。填补了当前 `write_item` 在文件操作方面的空白。

## 动机

当前 `write_item` 支持两个 action：

| action | 功能 | 局限 |
|--------|------|------|
| `create` | 创建新条目 + 重组已有独立附件 | 只能关联已存在于 Zotero 中的附件 |
| `reparent` | 将已有附件移动到另一个父条目下 | 操作对象必须是 Zotero 已知的附件 |

**缺少的能力**：将本地文件系统中的一个新文件导入为 Zotero 附件。

### 实际场景

在文献工作流中，用户常需要：

1. PDF → MinerU → Markdown 转换后，将 `.md` 文件自动附加到原文献条目
2. 从其他工具生成的笔记、图表等文件自动归档到 Zotero
3. 批量处理文献库时，自动化整个"转换→附加"流程

目前这些操作都需要用户手动在 Zotero GUI 中完成（右键 → "Attach Stored Copy of File"），无法通过 MCP 自动化。

## 方案

新增 `action: "import"`，接受以下参数：

| 参数 | 类型 | 必需 | 说明 |
|------|------|------|------|
| `filePath` | string | 是 | 要导入文件的绝对路径 |
| `parentItemKey` | string | 是 | 目标父条目的 Zotero item key |
| `title` | string | 否 | 附件的显示名称（默认使用文件名） |

底层调用 Zotero 内部 API `Zotero.Attachments.importFromFile()`，与 Zotero 自身导入附件的逻辑完全一致：

```typescript
const attachment = await Zotero.Attachments.importFromFile({
    file: filePath,
    parentItemID: parentItem.id,
    title: title || filePath.split(/[\/]/).pop() || 'Imported Attachment'
});
```

### 调用示例

```json
{
  "name": "write_item",
  "arguments": {
    "action": "import",
    "filePath": "C:\Users\...\Zotero\storage\Q4U34REQ\output.md",
    "parentItemKey": "YZXW7KL4"
  }
}
```

响应：

```json
{
  "action": "import",
  "success": true,
  "data": {
    "attachmentKey": "3NLKJNXV",
    "parentItemKey": "YZXW7KL4",
    "filePath": "C:\Users\...\output.md",
    "title": "output.md"
  }
}
```

## 改动范围

仅修改一个文件：`zotero-mcp-plugin/src/modules/streamableMCPServer.ts`

- 工具定义：`action` enum 增加 `import`，新增 `filePath` / `parentItemKey` 参数
- 处理函数 `callWriteItem`：新增 `import` case，含父条目校验 + `importFromFile` 调用

总计 +58 行，−6 行。

## 测试

在 Windows 10 + Zotero 7 环境下完成以下测试：

1. **14 页中文论文** (Shi et al. 2024, Front. Mar. Sci.)：PDF → MinerU MD → `import` action → 附件成功附加
2. **10 页英文论文** (Shi et al. 2025, Adv. Atmos. Sci.)：同样流程，附件 key `3NLKJNXV`，链接到父条目 `YZXW7KL4`

两个测试均验证了：
- 文件被正确复制到 Zotero storage 目录
- 附件与父条目的父子关系正确建立
- 返回值包含正确的 `attachmentKey`

## 向后兼容性

完全向后兼容。新增的 `import` 是 opt-in action，现有 `create` 和 `reparent` 行为不变。

---

感谢 review！