### PR TITLE
feat: add identifier lookup MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,13 +196,17 @@ Here are some screenshots demonstrating the functionality of Zotero MCP:
 
 ## 🔧 API Reference (MCP Tools)
 
-The integrated MCP server provides **20 tools** in 5 categories:
+The integrated MCP server provides tools in 5 categories:
 
-### 1. Search & Query (7 tools)
+### 1. Search & Query
 
 #### `search_library`
 Advanced library search with multi-dimensional filtering, boolean operators, relevance scoring, and intelligent mode control.
 - `q`, `title`, `titleOperator`, `yearRange`, `fulltext`, `fulltextMode`, `itemType`, `includeAttachments`, `mode` (minimal/preview/standard/complete), `relevanceScoring`, `sort`, `limit`, `offset`
+
+#### `lookup_identifier`
+Look up Zotero-style metadata from a DOI, DOI URL, arXiv ID, or arXiv URL without modifying the library.
+- `input` (required), `downloadPDF`, `attachmentDir`, `libraryID`
 
 #### `search_annotations`
 Search annotations by query, colors, or tags with intelligent ranking.
@@ -258,7 +262,7 @@ Get semantic search service status and index statistics. No parameters required.
 Access cached full-text content database (read-only).
 - `action` (required: list/search/get/stats), `query`, `itemKeys`, `limit`
 
-### 5. Write Operations (4 tools, can be disabled in preferences)
+### 5. Write Operations (can be disabled in preferences)
 
 #### `write_note`
 Create or modify Zotero notes. Supports Markdown auto-conversion to HTML.
@@ -275,6 +279,10 @@ Update metadata fields on items (title, abstract, date, DOI, creators, etc.).
 #### `write_item`
 Create new items or reparent existing attachments.
 - `action` (required: create/reparent), `itemType`, `fields`, `creators`, `tags`, `attachmentKeys`, `parentKey`
+
+#### `add_item_by_identifier`
+Create a Zotero item from a DOI, DOI URL, arXiv ID, or arXiv URL, and optionally download and import available PDF attachments.
+- `input` (required), `libraryID`, `downloadPDF`, `attachmentDir`
 
 ---
 

--- a/zotero-mcp-plugin/src/modules/identifierLookupService.ts
+++ b/zotero-mcp-plugin/src/modules/identifierLookupService.ts
@@ -1,0 +1,804 @@
+declare const PathUtils: any;
+
+export interface CreatorData {
+  creatorType: string;
+  firstName?: string;
+  lastName?: string;
+  name?: string;
+}
+
+export interface IdentifierAttachment {
+  title: string;
+  url: string;
+  mimeType: string;
+  path?: string;
+  size?: number;
+  downloadStatus?: "downloaded" | "failed";
+  downloadError?: string;
+}
+
+export interface IdentifierItem {
+  itemType: string;
+  title: string;
+  creators: CreatorData[];
+  abstractNote?: string;
+  date?: string;
+  DOI?: string;
+  url?: string;
+  publicationTitle?: string;
+  volume?: string;
+  issue?: string;
+  pages?: string;
+  publisher?: string;
+  repository?: string;
+  archiveID?: string;
+  number?: string;
+  extra?: string;
+  libraryCatalog?: string;
+  tags: Array<string | { tag: string }>;
+  attachments: IdentifierAttachment[];
+}
+
+export interface IdentifierLookupResult {
+  input: string;
+  identifier: {
+    type: "arXiv" | "DOI";
+    value: string;
+    version?: string;
+  };
+  items: IdentifierItem[];
+  writeItemPayloads: {
+    create: any;
+    importAttachments: any[];
+  };
+}
+
+export interface IdentifierLookupOptions {
+  downloadPDF?: boolean;
+  attachmentDir?: string;
+  libraryID?: number;
+}
+
+const ARXIV_CATEGORY_LABELS: Record<string, string> = {
+  cs: "Computer Science",
+  "cs.LG": "Machine Learning",
+};
+
+export async function lookupIdentifier(
+  input: string,
+  options: IdentifierLookupOptions = {},
+): Promise<IdentifierLookupResult> {
+  const identifier = extractIdentifier(input);
+  let item: IdentifierItem;
+
+  if (identifier.type === "arXiv") {
+    item = await lookupArXiv(identifier.value);
+  } else {
+    item = await lookupDOI(identifier.value);
+  }
+
+  if (options.downloadPDF === true) {
+    await downloadPDFAttachments(
+      item,
+      options.attachmentDir || getDefaultAttachmentDir(),
+    );
+  }
+
+  return {
+    input,
+    identifier,
+    items: [item],
+    writeItemPayloads: buildWriteItemPayloads(item, options),
+  };
+}
+
+export async function addItemByIdentifier(
+  input: string,
+  options: IdentifierLookupOptions = {},
+): Promise<any> {
+  const lookup = await lookupIdentifier(input, {
+    ...options,
+    downloadPDF: options.downloadPDF !== false,
+  });
+  const lookupItem = lookup.items[0];
+  const libraryID = options.libraryID || Zotero.Libraries.userLibraryID;
+  const item = new Zotero.Item(lookupItem.itemType as any);
+  item.libraryID = libraryID;
+
+  const skippedFields: Array<{ field: string; error: string }> = [];
+  for (const [fieldName, value] of Object.entries(itemToFields(lookupItem))) {
+    try {
+      item.setField(fieldName, String(value));
+    } catch (error) {
+      skippedFields.push({
+        field: fieldName,
+        error: String(error),
+      });
+    }
+  }
+
+  if (lookupItem.creators.length) {
+    item.setCreators(
+      lookupItem.creators.map((creator) => ({
+        creatorType: creator.creatorType || "author",
+        ...(creator.name
+          ? { name: creator.name }
+          : {
+              firstName: creator.firstName || "",
+              lastName: creator.lastName || "",
+            }),
+      })) as any,
+    );
+  }
+
+  for (const tag of normalizeTags(lookupItem.tags)) {
+    item.addTag(tag, 0);
+  }
+
+  await item.saveTx();
+
+  const importedAttachments = [];
+  for (const attachment of lookupItem.attachments || []) {
+    if (attachment.mimeType !== "application/pdf" || !attachment.path) {
+      continue;
+    }
+    try {
+      const imported = await Zotero.Attachments.importFromFile({
+        file: attachment.path,
+        parentItemID: item.id,
+        title: attachment.title || "Full Text PDF",
+      });
+      importedAttachments.push({
+        key: imported.key,
+        title: imported.getField("title"),
+        path: attachment.path,
+        sourceURL: attachment.url,
+      });
+    } catch (error) {
+      importedAttachments.push({
+        success: false,
+        path: attachment.path,
+        sourceURL: attachment.url,
+        error: String(error),
+      });
+    }
+  }
+
+  return {
+    action: "add_item_by_identifier",
+    success: true,
+    data: {
+      itemKey: item.key,
+      itemType: lookupItem.itemType,
+      title: lookupItem.title,
+      creatorsCount: lookupItem.creators.length,
+      tagsCount: normalizeTags(lookupItem.tags).length,
+      importedAttachments,
+      skippedFields,
+      dateCreated: item.dateAdded,
+    },
+    lookup,
+    metadata: {
+      extractedAt: new Date().toISOString(),
+      message: `Item created from identifier ${lookup.identifier.value} (key: ${item.key})`,
+    },
+  };
+}
+
+function extractIdentifier(
+  input: string,
+): IdentifierLookupResult["identifier"] {
+  const text = String(input || "").trim();
+  if (!text) {
+    throw new Error("No identifier provided");
+  }
+
+  const arXiv = extractArXivID(text);
+  if (arXiv) {
+    return { type: "arXiv", value: arXiv.id, version: arXiv.version };
+  }
+
+  const doi = cleanDOI(text);
+  if (doi) {
+    return { type: "DOI", value: doi };
+  }
+
+  throw new Error(`Unsupported identifier: ${text}`);
+}
+
+async function lookupArXiv(arXivID: string): Promise<IdentifierItem> {
+  const url = `https://export.arxiv.org/api/query?id_list=${encodeURIComponent(arXivID)}&max_results=1`;
+  const response = await fetch(url, {
+    headers: {
+      "User-Agent": "zotero-mcp-identifier-lookup/0.1",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`arXiv lookup failed: HTTP ${response.status}`);
+  }
+
+  const atom = await response.text();
+  const entry = atom.match(/<entry>([\s\S]*?)<\/entry>/);
+  if (!entry) {
+    throw new Error(`No arXiv record found for ${arXivID}`);
+  }
+
+  return arXivEntryToItem(entry[1], arXivID);
+}
+
+async function lookupDOI(doi: string): Promise<IdentifierItem> {
+  const url = `https://api.crossref.org/works/${encodeURIComponent(doi)}`;
+  const [response, landingURL] = await Promise.all([
+    fetch(url, {
+      headers: {
+        "User-Agent": "zotero-mcp-identifier-lookup/0.1",
+      },
+    }),
+    resolveDOIURL(doi),
+  ]);
+  if (!response.ok) {
+    throw new Error(`Crossref lookup failed: HTTP ${response.status}`);
+  }
+
+  const data = (await response.json()) as any;
+  const work = data.message;
+  const item: IdentifierItem = {
+    itemType: crossrefTypeToZoteroType(work.type),
+    title: first(work.title) || "",
+    creators: (work.author || []).map((author: any) => ({
+      creatorType: "author",
+      firstName: author.given || "",
+      lastName: author.family || author.name || "",
+    })),
+    abstractNote: stripTags(work.abstract || ""),
+    date: datePartsToZoteroDate(work.issued?.["date-parts"]?.[0] || []),
+    DOI: doi,
+    url: landingURL || work.URL || `https://doi.org/${doi}`,
+    publicationTitle: first(work["container-title"]) || "",
+    volume: work.volume || "",
+    issue: work.issue || "",
+    pages: work.page || "",
+    publisher: work.publisher || "",
+    libraryCatalog: "Crossref",
+    tags: [],
+    attachments: [],
+  };
+  item.attachments = getPDFAttachmentsForDOIItem(item, work);
+  return item;
+}
+
+async function resolveDOIURL(doi: string): Promise<string> {
+  try {
+    const response = await fetch(`https://doi.org/${encodeURIComponent(doi)}`, {
+      redirect: "manual",
+      headers: {
+        "User-Agent": "zotero-mcp-identifier-lookup/0.1",
+      },
+    });
+    return response.headers.get("location") || "";
+  } catch (_) {
+    return "";
+  }
+}
+
+function getPDFAttachmentsForDOIItem(
+  item: IdentifierItem,
+  work: any = {},
+): IdentifierAttachment[] {
+  const attachments: IdentifierAttachment[] = [];
+  const ieeeDocumentID = getIEEEDocumentID(item.url);
+  for (const link of work.link || []) {
+    if (
+      !isCrossrefPDFLink(link) ||
+      isDuplicateIEEEPDFLink(link, ieeeDocumentID)
+    ) {
+      continue;
+    }
+    addPDFAttachment(
+      attachments,
+      normalizePublisherPDFURL(link.URL, item, work) || link.URL,
+    );
+  }
+
+  if (ieeeDocumentID) {
+    addPDFAttachment(
+      attachments,
+      `https://ieeexplore.ieee.org/stampPDF/getPDF.jsp?tp=&arnumber=${ieeeDocumentID}&ref=`,
+    );
+  }
+
+  addPDFAttachment(attachments, getScienceDirectPDFURL(item, work));
+  addPDFAttachment(attachments, getSpringerPDFURL(item));
+  addPDFAttachment(attachments, getMDPIPDFURL(item, work));
+
+  return attachments;
+}
+
+function addPDFAttachment(attachments: IdentifierAttachment[], url: string) {
+  if (!url) {
+    return;
+  }
+  if (
+    attachments.some(
+      (attachment) => canonicalURL(attachment.url) === canonicalURL(url),
+    )
+  ) {
+    return;
+  }
+  attachments.push({
+    title: "Full Text PDF",
+    url,
+    mimeType: "application/pdf",
+  });
+}
+
+function isCrossrefPDFLink(link: any): boolean {
+  const url = String(link.URL || "");
+  const contentType = String(link["content-type"] || "").toLowerCase();
+  return (
+    contentType === "application/pdf" ||
+    /(?:\.pdf(?:[?#]|$)|\/pdf(?:[?#]|$)|\/pdfft(?:[?#]|$))/i.test(url)
+  );
+}
+
+function isDuplicateIEEEPDFLink(link: any, ieeeDocumentID: string): boolean {
+  return !!ieeeDocumentID && /ieee|xplore/i.test(String(link.URL || ""));
+}
+
+function normalizePublisherPDFURL(
+  url: string,
+  item: IdentifierItem,
+  work: any,
+): string {
+  if (/\.mdpi\.com\/.+\/pdf(?:[?#]|$)/i.test(String(url || ""))) {
+    return getMDPIPDFURL(item, work);
+  }
+  return url;
+}
+
+function getScienceDirectPDFURL(item: IdentifierItem, work: any): string {
+  let pii = getScienceDirectPII(item.url);
+  if (!pii) {
+    for (const link of work.link || []) {
+      pii = getScienceDirectPII(link.URL);
+      if (pii) {
+        break;
+      }
+    }
+  }
+  if (!pii) {
+    return "";
+  }
+  return `https://www.sciencedirect.com/science/article/pii/${pii}/pdfft?isDTMRedir=true&download=true`;
+}
+
+function getScienceDirectPII(url?: string): string {
+  const match = String(url || "").match(
+    /(?:retrieve\/pii\/|science\/article\/pii\/|PII:)([A-Z0-9]+)/i,
+  );
+  return match ? match[1] : "";
+}
+
+function getSpringerPDFURL(item: IdentifierItem): string {
+  const doi = String(item.DOI || "");
+  if (/^10\.1007\//i.test(doi)) {
+    return `https://link.springer.com/content/pdf/${doi}.pdf`;
+  }
+  if (/^10\.1038\//i.test(doi)) {
+    return `https://www.nature.com/articles/${doi.replace(/^10\.1038\//i, "")}.pdf`;
+  }
+  return "";
+}
+
+function getMDPIPDFURL(item: IdentifierItem, work: any): string {
+  if (!isMDPIItem(item, work)) {
+    return "";
+  }
+
+  const journal = first(work["short-container-title"]) || item.publicationTitle;
+  const volume = work.volume || item.volume;
+  const articleNumber = work.page || work["article-number"] || item.pages;
+  if (!journal || !volume || !articleNumber) {
+    return "";
+  }
+
+  const journalSlug = slugifyJournal(journal);
+  const articleID = String(articleNumber).replace(/\D/g, "").padStart(5, "0");
+  if (!journalSlug || !articleID) {
+    return "";
+  }
+
+  const stem = `${journalSlug}-${volume}-${articleID}`;
+  return `https://mdpi-res.com/d_attachment/${journalSlug}/${stem}/article_deploy/${stem}-v2.pdf`;
+}
+
+function isMDPIItem(item: IdentifierItem, work: any): boolean {
+  return (
+    /MDPI/i.test(String(work.publisher || "")) ||
+    /\.mdpi\.com\//i.test(String(item.url || ""))
+  );
+}
+
+function slugifyJournal(journal: string): string {
+  return String(journal || "")
+    .toLowerCase()
+    .replace(/&/g, "and")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function canonicalURL(url?: string): string {
+  return String(url || "")
+    .replace(/^https?:\/\//i, "")
+    .replace(/[?#].*$/, "")
+    .replace(/\/$/, "")
+    .toLowerCase();
+}
+
+function getIEEEDocumentID(url?: string): string {
+  const match = String(url || "").match(
+    /ieeexplore\.ieee\.org\/document\/(\d+)/i,
+  );
+  return match ? match[1] : "";
+}
+
+async function downloadPDFAttachments(
+  item: IdentifierItem,
+  attachmentDir: string,
+) {
+  const pdfAttachments = (item.attachments || []).filter(
+    (attachment) => attachment.mimeType === "application/pdf",
+  );
+  if (!pdfAttachments.length) {
+    return;
+  }
+
+  await IOUtils.makeDirectory(attachmentDir, {
+    createAncestors: true,
+    ignoreExisting: true,
+  });
+  for (const attachment of pdfAttachments) {
+    try {
+      const response = await fetch(attachment.url, {
+        headers: {
+          Accept: "application/pdf,*/*;q=0.8",
+          "User-Agent": "zotero-mcp-identifier-lookup/0.1",
+        },
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const bytes = new Uint8Array(await response.arrayBuffer());
+      if (!isPDF(bytes)) {
+        const contentType =
+          response.headers.get("content-type") || "unknown content type";
+        throw new Error(`not a PDF (${contentType})`);
+      }
+
+      const filePath = PathUtils.join(
+        attachmentDir,
+        safeFileName(`${item.title || item.DOI || "attachment"}.pdf`),
+      );
+      await IOUtils.write(filePath, bytes);
+      attachment.path = filePath;
+      attachment.size = bytes.byteLength;
+      attachment.downloadStatus = "downloaded";
+    } catch (error) {
+      attachment.downloadStatus = "failed";
+      attachment.downloadError =
+        error instanceof Error ? error.message : String(error);
+    }
+  }
+}
+
+function isPDF(bytes: Uint8Array): boolean {
+  return (
+    bytes.length >= 4 &&
+    bytes[0] === 0x25 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x44 &&
+    bytes[3] === 0x46
+  );
+}
+
+function safeFileName(fileName: string): string {
+  return fileName
+    .replace(/[\\/:*?"<>|]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 180);
+}
+
+function getDefaultAttachmentDir(): string {
+  return PathUtils.join(PathUtils.tempDir, "zotero-mcp-identifier-lookup");
+}
+
+function datePartsToZoteroDate(parts: number[]): string {
+  if (!parts.length) {
+    return "";
+  }
+  const [year, month, day] = parts;
+  if (year && month && day) {
+    return `${month}/${day}/${year}`;
+  }
+  if (year && month) {
+    return `${month}/${year}`;
+  }
+  return String(year || "");
+}
+
+function arXivEntryToItem(entry: string, requestedID: string): IdentifierItem {
+  const versionedURL =
+    getText(entry, "id") || `http://arxiv.org/abs/${requestedID}`;
+  const versionedID = extractArXivID(versionedURL)?.id || requestedID;
+  const arXivURL = versionedURL.replace(/v\d+$/, "");
+  const articleID =
+    (arXivURL.match(/\/abs\/(.+)$/) || [])[1] ||
+    versionedID.replace(/v\d+$/, "");
+  const version = (versionedID.match(/v(\d+)$/) || [])[1];
+  const pdfURL = versionedURL.replace("/abs/", "/pdf/");
+  const primaryCategory =
+    getAttribute(entry, "arxiv:primary_category", "term") ||
+    getAttribute(entry, "primary_category", "term") ||
+    "";
+  const primaryField = primaryCategory
+    .replace(/^.+?:/, "")
+    .replace(/\..+$/, "");
+  const doi = getText(entry, "arxiv:doi") || getText(entry, "doi");
+  let extra = `arXiv:${articleID}`;
+  if (primaryField) {
+    extra += ` [${primaryField}]`;
+  }
+  if (version) {
+    extra += `\nversion: ${version}`;
+  }
+
+  return {
+    itemType: "preprint",
+    title: normalizeText(getText(entry, "title")),
+    creators: getAuthorNames(entry).map((name) => cleanAuthor(name)),
+    abstractNote: normalizeText(getText(entry, "summary")),
+    date: isoDate(getText(entry, "updated") || getText(entry, "published")),
+    DOI: doi || `10.48550/arXiv.${articleID}`,
+    url: arXivURL,
+    repository: "arXiv",
+    archiveID: `arXiv:${articleID}`,
+    number: `arXiv:${articleID}`,
+    extra,
+    libraryCatalog: "arXiv.org",
+    tags: getCategories(entry)
+      .map(formatArXivCategory)
+      .map((tag) => ({ tag })),
+    attachments: [
+      {
+        title: "Preprint PDF",
+        url: pdfURL,
+        mimeType: "application/pdf",
+      },
+      {
+        title: "Snapshot",
+        url: arXivURL,
+        mimeType: "text/html",
+      },
+    ],
+  };
+}
+
+function buildWriteItemPayloads(
+  item: IdentifierItem,
+  options: IdentifierLookupOptions,
+) {
+  const create: any = {
+    action: "create",
+    itemType: item.itemType,
+    fields: itemToFields(item),
+    creators: item.creators,
+    tags: normalizeTags(item.tags),
+  };
+  if (options.libraryID != null) {
+    create.libraryID = options.libraryID;
+  }
+
+  const importAttachments = (item.attachments || [])
+    .filter(
+      (attachment) =>
+        attachment.mimeType === "application/pdf" && attachment.path,
+    )
+    .map((attachment) => ({
+      action: "import",
+      parentItemKey: "<created-item-key>",
+      filePath: attachment.path,
+      title: attachment.title || "Full Text PDF",
+      ...(options.libraryID != null ? { libraryID: options.libraryID } : {}),
+    }));
+
+  return {
+    create,
+    importAttachments,
+  };
+}
+
+function itemToFields(item: IdentifierItem): Record<string, string> {
+  const fields: Record<string, string> = {};
+  for (const field of [
+    "title",
+    "abstractNote",
+    "date",
+    "DOI",
+    "url",
+    "publicationTitle",
+    "volume",
+    "issue",
+    "pages",
+    "publisher",
+    "repository",
+    "archiveID",
+    "number",
+    "extra",
+  ]) {
+    const value = item[field as keyof IdentifierItem];
+    if (typeof value === "string" && value) {
+      fields[field] = value;
+    }
+  }
+  return fields;
+}
+
+function normalizeTags(tags: Array<string | { tag: string }>): string[] {
+  return tags
+    .map((tag) => (typeof tag === "string" ? tag : tag.tag))
+    .filter(Boolean);
+}
+
+function extractArXivID(text: string): { id: string; version?: string } | null {
+  let match = text.match(/arxiv\.org\/(?:abs|pdf)\/([^?#\s]+)/i);
+  let id = match ? match[1] : null;
+  if (!id) {
+    match = text.match(
+      /(?:^|\s)arXiv:([A-Za-z.-]+\/\d{7}|\d{4}\.\d{4,5})(v\d+)?/i,
+    );
+    if (match) {
+      id = match[1] + (match[2] || "");
+    }
+  }
+  if (!id) {
+    match = text.match(
+      /(?:^|\s)([A-Za-z.-]+\/\d{7}|\d{4}\.\d{4,5})(v\d+)?(?:\s|$)/i,
+    );
+    if (match) {
+      id = match[1] + (match[2] || "");
+    }
+  }
+  if (!id) {
+    return null;
+  }
+  id = id.replace(/\.pdf$/i, "").replace(/\/$/, "");
+  const version = (id.match(/v(\d+)$/) || [])[1];
+  return { id, version };
+}
+
+function cleanDOI(text: string): string | null {
+  let decoded = text;
+  try {
+    decoded = decodeURIComponent(text);
+  } catch (_) {
+    // Keep original text if it is not URI-encoded cleanly.
+  }
+  const match = decoded.match(
+    /10(?:\.[0-9]{4,})?\/[^\s<>"']*[^\s<>"'.,;:)\]}]/,
+  );
+  return match ? match[0] : null;
+}
+
+function getText(xml: string, tagName: string): string {
+  const escaped = tagName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(
+    `<${escaped}(?:\\s[^>]*)?>([\\s\\S]*?)<\\/${escaped}>`,
+    "i",
+  );
+  const match = xml.match(pattern);
+  return match ? decodeXML(match[1]) : "";
+}
+
+function getAttribute(xml: string, tagName: string, attrName: string): string {
+  const escapedTag = tagName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escapedAttr = attrName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(
+    `<${escapedTag}[^>]*\\s${escapedAttr}="([^"]*)"`,
+    "i",
+  );
+  const match = xml.match(pattern);
+  return match ? decodeXML(match[1]) : "";
+}
+
+function getAuthorNames(entry: string): string[] {
+  return [
+    ...entry.matchAll(/<author>\s*<name>([\s\S]*?)<\/name>\s*<\/author>/gi),
+  ]
+    .map((match) => normalizeText(decodeXML(match[1])))
+    .filter(Boolean);
+}
+
+function getCategories(entry: string): string[] {
+  return [...entry.matchAll(/<category[^>]*\sterm="([^"]+)"/gi)]
+    .map((match) => decodeXML(match[1]))
+    .filter(Boolean);
+}
+
+function formatArXivCategory(term: string): string {
+  const mainCategory = term.split(".")[0];
+  if (
+    mainCategory !== term &&
+    ARXIV_CATEGORY_LABELS[mainCategory] &&
+    ARXIV_CATEGORY_LABELS[term]
+  ) {
+    return `${ARXIV_CATEGORY_LABELS[mainCategory]} - ${ARXIV_CATEGORY_LABELS[term]}`;
+  }
+  return ARXIV_CATEGORY_LABELS[term] || term;
+}
+
+function cleanAuthor(name: string): CreatorData {
+  if (name.includes(",")) {
+    const [lastName, ...rest] = name.split(",");
+    return {
+      creatorType: "author",
+      firstName: rest.join(",").trim(),
+      lastName: lastName.trim(),
+    };
+  }
+  const parts = name.trim().split(/\s+/);
+  if (parts.length === 1) {
+    return {
+      creatorType: "author",
+      lastName: parts[0],
+    };
+  }
+  return {
+    creatorType: "author",
+    firstName: parts.slice(0, -1).join(" "),
+    lastName: parts[parts.length - 1],
+  };
+}
+
+function normalizeText(text: string): string {
+  return decodeXML(text).replace(/\s+/g, " ").trim();
+}
+
+function decodeXML(text: string): string {
+  return String(text || "")
+    .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, "$1")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+function isoDate(value: string): string {
+  const match = String(value || "").match(/^\d{4}-\d{2}-\d{2}/);
+  return match ? match[0] : "";
+}
+
+function first(value: any): string {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function stripTags(value: string): string {
+  return String(value || "")
+    .replace(/<[^>]+>/g, "")
+    .trim();
+}
+
+function crossrefTypeToZoteroType(type: string): string {
+  if (type === "book" || type === "monograph") {
+    return "book";
+  }
+  if (type === "book-chapter") {
+    return "bookSection";
+  }
+  if (type === "posted-content") {
+    return "preprint";
+  }
+  return "journalArticle";
+}

--- a/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
+++ b/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
@@ -20,6 +20,7 @@ import { UnifiedContentExtractor } from './unifiedContentExtractor';
 import { SmartAnnotationExtractor } from './smartAnnotationExtractor';
 import { MCPSettingsService } from './mcpSettingsService';
 import { getSemanticSearchService, SemanticSearchService } from './semantic';
+import { addItemByIdentifier, lookupIdentifier } from './identifierLookupService';
 
 export interface MCPRequest {
   jsonrpc: '2.0';
@@ -802,6 +803,32 @@ export class StreamableMCPServer {
           required: ['itemKey'],
         },
       },
+      {
+        name: 'lookup_identifier',
+        description: 'Look up Zotero-style metadata from a DOI, DOI URL, arXiv ID, or arXiv URL. Returns normalized item metadata, PDF candidates, and write_item-compatible payloads without modifying the library.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            input: {
+              type: 'string',
+              description: 'Identifier or URL, e.g. 10.1109/JBHI.2025.3633456, https://doi.org/..., or https://arxiv.org/abs/2605.05806'
+            },
+            downloadPDF: {
+              type: 'boolean',
+              description: 'Download discovered PDF attachments to a temporary local directory when possible. Default: false.'
+            },
+            attachmentDir: {
+              type: 'string',
+              description: 'Directory for downloaded PDFs. Defaults to a temporary Zotero MCP directory.'
+            },
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID to include in returned write_item payloads.'
+            }
+          },
+          required: ['input']
+        }
+      },
       // Semantic Search Tools
       {
         name: 'semantic_search',
@@ -1065,6 +1092,32 @@ export class StreamableMCPServer {
           },
           required: ['action']
         }
+      },
+      {
+        name: 'add_item_by_identifier',
+        description: 'Create a Zotero item from a DOI, DOI URL, arXiv ID, or arXiv URL, similar to Zotero\'s Add Item by Identifier. Optionally downloads and imports available PDF attachments. Confirm with user before executing.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
+            input: {
+              type: 'string',
+              description: 'Identifier or URL, e.g. 10.1109/JBHI.2025.3633456, https://doi.org/..., or https://arxiv.org/abs/2605.05806'
+            },
+            downloadPDF: {
+              type: 'boolean',
+              description: 'Attempt to download and import discovered PDF attachments. Default: true.'
+            },
+            attachmentDir: {
+              type: 'string',
+              description: 'Directory for temporary downloaded PDFs. Defaults to a temporary Zotero MCP directory.'
+            }
+          },
+          required: ['input']
+        }
       }
     ];
 
@@ -1078,7 +1131,7 @@ export class StreamableMCPServer {
     // Filter out write tools if write operations are disabled (default: disabled)
     const writeEnabled = Zotero.Prefs.get('extensions.zotero.zotero-mcp-plugin.write.enabled', true);
     const writeToolNames = new Set([
-      'write_note', 'write_tag', 'write_metadata', 'write_item',
+      'write_note', 'write_tag', 'write_metadata', 'write_item', 'add_item_by_identifier',
     ]);
     const finalTools = writeEnabled === true
       ? filteredTools
@@ -1249,6 +1302,17 @@ export class StreamableMCPServer {
           result = await this.callGetItemAbstract(args);
           break;
 
+        case 'lookup_identifier':
+          if (!args?.input) {
+            throw new Error('input is required');
+          }
+          result = await lookupIdentifier(args.input, {
+            downloadPDF: args.downloadPDF === true,
+            attachmentDir: args.attachmentDir,
+            libraryID: args.libraryID,
+          });
+          break;
+
         // Semantic Search Tools
         case 'semantic_search':
         case 'find_similar':
@@ -1328,6 +1392,22 @@ export class StreamableMCPServer {
           break;
         }
 
+        case 'add_item_by_identifier': {
+          const writeEnabled5 = Zotero.Prefs.get('extensions.zotero.zotero-mcp-plugin.write.enabled', true);
+          if (writeEnabled5 !== true) {
+            throw new Error('Write operations are currently disabled. Please go to Zotero → Tools → Add-ons → Zotero MCP Plugin → Preferences, and enable "Write Operations" to use this feature.');
+          }
+          if (!args?.input) {
+            throw new Error('input is required');
+          }
+          result = await addItemByIdentifier(args.input, {
+            downloadPDF: args.downloadPDF,
+            attachmentDir: args.attachmentDir,
+            libraryID: args.libraryID,
+          });
+          break;
+        }
+
         default:
           throw new Error(`Unknown tool: ${name}`);
       }
@@ -1403,7 +1483,7 @@ export class StreamableMCPServer {
       setTimeout(() => reject(new Error("Search timed out after 25 seconds. Try narrowing your query or reducing the limit.")), SEARCH_TIMEOUT_MS);
     });
     const response = await Promise.race([searchPromise, timeoutPromise]);
-    let result = response.body ? JSON.parse(response.body) : response;
+    const result = response.body ? JSON.parse(response.body) : response;
     
     // Add mode information to metadata
     if (result && typeof result === 'object') {
@@ -1453,7 +1533,7 @@ export class StreamableMCPServer {
     
     // Call the dedicated item details handler
     const response = await handleGetItem({ 1: itemKey }, queryParams);
-    let result = response.body ? JSON.parse(response.body) : response;
+    const result = response.body ? JSON.parse(response.body) : response;
     
     // Add mode information to metadata
     if (result && typeof result === 'object') {
@@ -1525,7 +1605,7 @@ export class StreamableMCPServer {
     }
     
     const response = await handleGetCollections(collectionParams);
-    let result = response.body ? JSON.parse(response.body) : response;
+    const result = response.body ? JSON.parse(response.body) : response;
     
     // Add mode information to metadata
     if (result && typeof result === 'object') {
@@ -1672,7 +1752,7 @@ export class StreamableMCPServer {
     }
     
     const response = await handleSearchFulltext(searchParams);
-    let result = response.body ? JSON.parse(response.body) : response;
+    const result = response.body ? JSON.parse(response.body) : response;
     
     // Add mode information to metadata
     if (result && typeof result === 'object') {
@@ -2745,6 +2825,7 @@ export class StreamableMCPServer {
         'get_collection_items',
         'search_fulltext',
         'get_item_abstract',
+        'lookup_identifier',
         // Semantic Search Tools (read-only)
         'semantic_search',
         'find_similar',
@@ -2755,7 +2836,8 @@ export class StreamableMCPServer {
         'write_note',
         'write_tag',
         'write_metadata',
-        'write_item'
+        'write_item',
+        'add_item_by_identifier'
       ],
       transport: {
         type: "streamable-http",


### PR DESCRIPTION
## Summary

This adds two MCP tools for working with bibliographic identifiers (similar to the "Magic Wand" in Zotero Desktop):

- `lookup_identifier` resolves an identifier into item metadata
- `add_item_by_identifier` creates a Zotero item from an identifier, with optional PDF download/attachment handling

The first version supports DOI and arXiv identifiers. DOI metadata is resolved through Crossref, and arXiv metadata is resolved through the arXiv API. PDF downloads are best-effort and depend on what the publisher exposes.

## Notes

- `add_item_by_identifier` follows the existing write-enabled preference.
- When writes are disabled, the write tool is not exposed and cannot be called.
- The implementation keeps the feature inside the existing plugin API and does not require a separate service.

## Testing

- Ran targeted ESLint on the modified files.
- Ran the plugin build.
- Manually tested lookup and item creation against a local Zotero instance with arXiv and DOI inputs.