### PR TITLE
feat: expose Zotero Extra field in item details

### DIFF
--- a/zotero-mcp-plugin/src/modules/apiHandlers.ts
+++ b/zotero-mcp-plugin/src/modules/apiHandlers.ts
@@ -40,6 +40,12 @@ function resolveLibraryID(query: URLSearchParams): number {
     throw new MCPError(400, "Invalid libraryID: must be an integer");
   }
 
+  // Some MCP clients pass 0 as a placeholder for the default user library.
+  // Zotero library IDs are positive; treat 0 the same as an omitted libraryID.
+  if (libraryID === 0) {
+    return Zotero.Libraries.userLibraryID;
+  }
+
   return libraryID;
 }
 

--- a/zotero-mcp-plugin/src/modules/itemFormatter.ts
+++ b/zotero-mcp-plugin/src/modules/itemFormatter.ts
@@ -43,6 +43,7 @@ export async function formatItem(
       "pages",
       "DOI",
       "url",
+      "extra",
       "abstractNote",
       "tags",
       "notes",

--- a/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
+++ b/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
@@ -2245,7 +2245,10 @@ export class StreamableMCPServer {
    * Handle write_metadata tool calls: update fields and creators on items
    */
   private async callWriteMetadata(args: any): Promise<any> {
-    const { itemKey, fields, creators, libraryID = Zotero.Libraries.userLibraryID } = args;
+    const { itemKey, fields, creators } = args;
+    const libraryID = args.libraryID === 0 || args.libraryID === undefined || args.libraryID === null
+      ? Zotero.Libraries.userLibraryID
+      : args.libraryID;
 
     try {
       const item = await Zotero.Items.getByLibraryAndKeyAsync(
@@ -2844,7 +2847,7 @@ export class StreamableMCPServer {
         fields: ['key', 'title', 'creators', 'date', 'itemType']
       },
       'preview': {
-        fields: ['key', 'title', 'creators', 'date', 'itemType', 'abstractNote', 'tags', 'collections']
+        fields: ['key', 'title', 'creators', 'date', 'itemType', 'abstractNote', 'extra', 'tags', 'collections']
       },
       'standard': {
         fields: null // Include most fields (default behavior)


### PR DESCRIPTION
Include the Zotero Extra field in get_item_details output for both default and preview modes.

Also normalize libraryID=0 to the default user library for item detail reads and write_metadata updates, matching MCP clients that use 0 as a placeholder for the user library.