### PR TITLE
fix(http): read request bodies as bytes to stop UTF-8 corruption

### DIFF
--- a/zotero-mcp-plugin/.mocharc.json
+++ b/zotero-mcp-plugin/.mocharc.json
@@ -1,0 +1,4 @@
+{
+  "spec": ["test/**/*.test.ts"],
+  "node-option": ["experimental-strip-types", "no-warnings"]
+}

--- a/zotero-mcp-plugin/package-lock.json
+++ b/zotero-mcp-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zotero-mcp-plugin",
-  "version": "1.4.7",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zotero-mcp-plugin",
-      "version": "1.4.7",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "zotero-plugin-toolkit": "^5.1.2"

--- a/zotero-mcp-plugin/package.json
+++ b/zotero-mcp-plugin/package.json
@@ -30,6 +30,7 @@
     "prepare-release": "node scripts/prepare-release.js",
     "release:init": "node scripts/init-release.js",
     "test": "zotero-plugin test",
+    "test:unit": "mocha",
     "test:update": "node scripts/test-update.js",
     "update-deps": "npm update --save"
   },

--- a/zotero-mcp-plugin/src/modules/httpRequestReader.ts
+++ b/zotero-mcp-plugin/src/modules/httpRequestReader.ts
@@ -1,0 +1,275 @@
+/**
+ * Byte-level HTTP request reader.
+ *
+ * Deliberately free of XPCOM and Zotero globals so it can be unit-tested with
+ * a fake socket that places chunk boundaries anywhere - including inside a
+ * multibyte UTF-8 sequence, which is what the v1.5.0 body-corruption bug
+ * depended on.
+ *
+ * The rule this module exists to enforce: HTTP framing is byte-denominated
+ * (Content-Length counts bytes, the header terminator is a byte sequence), so
+ * every read, offset and comparison here is in bytes. Text decoding happens
+ * exactly once, at the end, on a complete buffer.
+ */
+
+/** Minimal socket abstraction: the XPCOM binary input stream fits this. */
+export interface ByteReader {
+  /** Bytes currently readable without blocking. */
+  available(): number;
+  /**
+   * Read up to `count` bytes. Callers never request more than `available()`
+   * reported, so a conforming reader returns exactly `count` bytes.
+   */
+  readBytes(count: number): Uint8Array;
+}
+
+export interface HttpRequestReadOptions {
+  /** Hard cap on a single request, in bytes. Default 1 MiB. */
+  maxRequestSize?: number;
+  /** Consecutive empty polls tolerated before giving up. Default 50. */
+  maxWaitAttempts?: number;
+  /** Delay between empty polls, in ms. Default 10. */
+  waitMs?: number;
+  /** Injectable for tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface HttpRequestRead {
+  /** Decoded header block, excluding the terminating CRLFCRLF. */
+  headerText: string;
+  /** Decoded body, exactly `contentLength` bytes worth. */
+  body: string;
+  /** Declared Content-Length in bytes (0 when absent). */
+  contentLength: number;
+  /** Body bytes actually received; less than contentLength when truncated. */
+  bodyBytesRead: number;
+  /** Total bytes pulled off the socket. */
+  totalBytesRead: number;
+  /** Bytes read beyond the end of this request (pipelined next request). */
+  trailingBytes: number;
+  /** False when headers never terminated or the body never reached Content-Length. */
+  complete: boolean;
+  /** Set when the read stopped early; used for diagnostics. */
+  incompleteReason?: "no-data" | "headers-truncated" | "body-truncated" | "too-large";
+}
+
+const CR = 0x0d;
+const LF = 0x0a;
+
+const DEFAULTS = {
+  maxRequestSize: 1024 * 1024,
+  maxWaitAttempts: 50,
+  waitMs: 10,
+};
+
+/** Header-phase read budget. Bytes, not characters. */
+const HEADER_CHUNK = 4096;
+/** Body-phase read budget. Bytes, not characters. */
+const BODY_CHUNK = 8192;
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Locate the CRLFCRLF header terminator.
+ *
+ * @returns index of the first CR of the terminator, or -1.
+ */
+export function indexOfHeaderTerminator(
+  bytes: Uint8Array,
+  length: number,
+  from = 0,
+): number {
+  // Back up 3 bytes so a terminator straddling the previous scan is still found.
+  const start = Math.max(0, from - 3);
+  for (let i = start; i + 3 < length; i++) {
+    if (
+      bytes[i] === CR &&
+      bytes[i + 1] === LF &&
+      bytes[i + 2] === CR &&
+      bytes[i + 3] === LF
+    ) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+/** Parse Content-Length from a decoded header block. Returns 0 when absent. */
+export function parseContentLength(headerText: string): number {
+  const match = headerText.match(/^Content-Length:[ \t]*(\d+)[ \t]*$/im);
+  if (!match) return 0;
+  const value = parseInt(match[1], 10);
+  return Number.isFinite(value) && value >= 0 ? value : 0;
+}
+
+/** Growable byte buffer. Avoids re-allocating per chunk. */
+class ByteBuffer {
+  private buf: Uint8Array;
+  length = 0;
+
+  constructor(initial = 8192) {
+    this.buf = new Uint8Array(initial);
+  }
+
+  append(chunk: Uint8Array): void {
+    const needed = this.length + chunk.length;
+    if (needed > this.buf.length) {
+      let size = this.buf.length * 2;
+      while (size < needed) size *= 2;
+      const next = new Uint8Array(size);
+      next.set(this.buf.subarray(0, this.length), 0);
+      this.buf = next;
+    }
+    this.buf.set(chunk, this.length);
+    this.length = needed;
+  }
+
+  bytes(): Uint8Array {
+    return this.buf;
+  }
+
+  slice(start: number, end: number): Uint8Array {
+    return this.buf.subarray(start, Math.min(end, this.length));
+  }
+}
+
+/**
+ * Read one complete HTTP request off `reader`.
+ *
+ * Headers and body are accumulated as raw bytes and decoded once at the end,
+ * so no read boundary can split a UTF-8 sequence.
+ */
+export async function readHttpRequest(
+  reader: ByteReader,
+  options: HttpRequestReadOptions = {},
+): Promise<HttpRequestRead> {
+  const maxRequestSize = options.maxRequestSize ?? DEFAULTS.maxRequestSize;
+  const maxWaitAttempts = options.maxWaitAttempts ?? DEFAULTS.maxWaitAttempts;
+  const waitMs = options.waitMs ?? DEFAULTS.waitMs;
+  const sleep = options.sleep ?? defaultSleep;
+
+  const buffer = new ByteBuffer();
+  let waitAttempts = 0;
+  let scanned = 0;
+  let headerEnd = -1;
+  let contentLength = 0;
+  let headerText = "";
+  let bodyEnd = -1;
+  let incompleteReason: HttpRequestRead["incompleteReason"];
+
+  // Single loop for both phases: the target end offset is unknown until the
+  // headers are parsed, at which point it becomes headerEnd + 4 + contentLength.
+  for (;;) {
+    if (bodyEnd >= 0 && buffer.length >= bodyEnd) break;
+
+    if (buffer.length >= maxRequestSize) {
+      incompleteReason = "too-large";
+      break;
+    }
+
+    // Never read past the end of this request: any excess belongs to a
+    // pipelined follow-up on the same socket.
+    const budget =
+      bodyEnd >= 0
+        ? Math.min(BODY_CHUNK, bodyEnd - buffer.length)
+        : Math.min(HEADER_CHUNK, maxRequestSize - buffer.length);
+
+    let available = 0;
+    try {
+      available = reader.available();
+    } catch {
+      // Stream closed underneath us.
+      available = 0;
+    }
+
+    if (available <= 0) {
+      waitAttempts++;
+      if (waitAttempts > maxWaitAttempts) {
+        incompleteReason =
+          headerEnd < 0 ? (buffer.length === 0 ? "no-data" : "headers-truncated") : "body-truncated";
+        break;
+      }
+      await sleep(waitMs);
+      continue;
+    }
+
+    let chunk: Uint8Array;
+    try {
+      chunk = reader.readBytes(Math.min(budget, available));
+    } catch {
+      // A live socket reporting data but failing to deliver it means EOF.
+      incompleteReason =
+        headerEnd < 0 ? "headers-truncated" : "body-truncated";
+      break;
+    }
+
+    if (!chunk || chunk.length === 0) {
+      incompleteReason =
+        headerEnd < 0
+          ? buffer.length === 0
+            ? "no-data"
+            : "headers-truncated"
+          : "body-truncated";
+      break;
+    }
+
+    waitAttempts = 0;
+    buffer.append(chunk);
+
+    if (headerEnd < 0) {
+      const found = indexOfHeaderTerminator(
+        buffer.bytes(),
+        buffer.length,
+        scanned,
+      );
+      scanned = buffer.length;
+      if (found >= 0) {
+        headerEnd = found;
+        headerText = decodeUtf8(buffer.slice(0, headerEnd));
+        contentLength = parseContentLength(headerText);
+        bodyEnd = headerEnd + 4 + contentLength;
+      }
+    }
+  }
+
+  if (headerEnd < 0) {
+    return {
+      headerText: buffer.length > 0 ? decodeUtf8(buffer.slice(0, buffer.length)) : "",
+      body: "",
+      contentLength: 0,
+      bodyBytesRead: 0,
+      totalBytesRead: buffer.length,
+      trailingBytes: 0,
+      complete: false,
+      incompleteReason: incompleteReason ?? "headers-truncated",
+    };
+  }
+
+  const bodyStart = headerEnd + 4;
+  const bodyBytesRead = Math.max(0, buffer.length - bodyStart);
+  const complete = bodyBytesRead >= contentLength && !incompleteReason;
+
+  return {
+    headerText,
+    // Decode exactly Content-Length bytes, once, from a complete buffer.
+    body: decodeUtf8(buffer.slice(bodyStart, bodyStart + contentLength)),
+    contentLength,
+    bodyBytesRead: Math.min(bodyBytesRead, contentLength),
+    totalBytesRead: buffer.length,
+    trailingBytes: Math.max(0, buffer.length - bodyEnd),
+    complete,
+    incompleteReason: complete ? undefined : incompleteReason ?? "body-truncated",
+  };
+}
+
+/** Decode UTF-8 bytes to a string, substituting U+FFFD for malformed input. */
+export function decodeUtf8(bytes: Uint8Array): string {
+  if (bytes.length === 0) return "";
+  return new TextDecoder("utf-8").decode(bytes);
+}
+
+/** UTF-8 byte length of a string. */
+export function getByteLength(str: string): number {
+  return new TextEncoder().encode(str).length;
+}

--- a/zotero-mcp-plugin/src/modules/httpServer.ts
+++ b/zotero-mcp-plugin/src/modules/httpServer.ts
@@ -1,79 +1,13 @@
 import { StreamableMCPServer } from "./streamableMCPServer";
 import { serverPreferences } from "./serverPreferences";
 import { testMCPIntegration } from "./mcpTest";
+import {
+  readHttpRequest,
+  getByteLength,
+  type ByteReader,
+} from "./httpRequestReader";
 
 declare let ztoolkit: ZToolkit;
-
-/**
- * Helper to get UTF-8 byte length of a string
- */
-function getByteLength(str: string): number {
-  // Use TextEncoder for accurate UTF-8 byte count
-  try {
-    return new TextEncoder().encode(str).length;
-  } catch {
-    // Fallback for environments without TextEncoder
-    let bytes = 0;
-    for (let i = 0; i < str.length; i++) {
-      const charCode = str.charCodeAt(i);
-      if (charCode < 0x80) bytes += 1;
-      else if (charCode < 0x800) bytes += 2;
-      else if (charCode < 0xd800 || charCode >= 0xe000) bytes += 3;
-      else { // surrogate pair
-        i++;
-        bytes += 4;
-      }
-    }
-    return bytes;
-  }
-}
-
-/**
- * Slice string by UTF-8 byte length without splitting multibyte characters.
- */
-function sliceByUtf8Bytes(str: string, maxBytes: number): string {
-  if (maxBytes <= 0 || !str) {
-    return "";
-  }
-
-  let bytes = 0;
-  let end = 0;
-
-  for (let i = 0; i < str.length; i++) {
-    const code = str.charCodeAt(i);
-    let charBytes = 0;
-
-    if (code < 0x80) {
-      charBytes = 1;
-    } else if (code < 0x800) {
-      charBytes = 2;
-    } else if (code >= 0xd800 && code <= 0xdbff && i + 1 < str.length) {
-      const next = str.charCodeAt(i + 1);
-      if (next >= 0xdc00 && next <= 0xdfff) {
-        charBytes = 4;
-      } else {
-        charBytes = 3;
-      }
-    } else {
-      charBytes = 3;
-    }
-
-    if (bytes + charBytes > maxBytes) {
-      break;
-    }
-
-    bytes += charBytes;
-    end = i + 1;
-
-    // Skip low surrogate after consuming a valid pair.
-    if (charBytes === 4) {
-      i++;
-      end = i + 1;
-    }
-  }
-
-  return str.substring(0, end);
-}
 
 /**
  * Write string to output stream with correct UTF-8 encoding
@@ -268,7 +202,7 @@ export class HttpServer {
   /**
    * Determine if connection should be kept alive based on request
    */
-  private shouldKeepAlive(requestText: string, path: string): boolean {
+  private shouldKeepAlive(headerText: string, path: string): boolean {
     // Current listener lifecycle handles one request per socket and closes
     // streams in finally. Do not advertise keep-alive for MCP endpoints.
     if (path === "/mcp" || path.startsWith("/mcp/")) {
@@ -276,7 +210,7 @@ export class HttpServer {
     }
     
     // Check for Connection header in request
-    const connectionHeader = requestText.match(/Connection:\s*([^\r\n]+)/i);
+    const connectionHeader = headerText.match(/Connection:\s*([^\r\n]+)/i);
     if (connectionHeader && connectionHeader[1].toLowerCase().includes('keep-alive')) {
       return true;
     }
@@ -313,8 +247,7 @@ export class HttpServer {
     onSocketAccepted: async (_socket: any, transport: any) => {
       let input: any = null;
       let output: any = null;
-      let sin: any = null;
-      const converterStream: any = null;
+      let binaryStream: any = null;
 
       // Track this transport for cleanup on shutdown
       this.activeTransports.add(transport);
@@ -325,159 +258,50 @@ export class HttpServer {
         input = transport.openInputStream(0, 0, 0);
         output = transport.openOutputStream(0, 0, 0);
 
-        // 使用转换输入流来正确处理UTF-8编码
-        const converterStream = Cc[
-          "@mozilla.org/intl/converter-input-stream;1"
-        ].createInstance(Ci.nsIConverterInputStream);
-        converterStream.init(input, "UTF-8", 0, 0);
-
-        sin = Cc["@mozilla.org/scriptableinputstream;1"].createInstance(
-          Ci.nsIScriptableInputStream,
+        // Read the request as raw bytes and decode once, at the end.
+        // A decoding stream must never be used here: HTTP framing is
+        // byte-denominated, and incremental decode + byte/char mixing
+        // corrupted every non-ASCII body (see httpRequestReader.ts).
+        binaryStream = Cc["@mozilla.org/binaryinputstream;1"].createInstance(
+          Ci.nsIBinaryInputStream,
         );
-        sin.init(input);
+        binaryStream.setInputStream(input);
 
-        // 改进请求读取逻辑 - 读取完整的HTTP请求（包括body）
-        let requestText = "";
-        let totalBytesRead = 0;
-        const maxRequestSize = 1024 * 1024; // 1MB max request size
-        let waitAttempts = 0;
-        const maxWaitAttempts = 50; // Increase wait attempts for larger requests
-        let headersComplete = false;
-        let contentLength = 0;
-        let bodyStartIndex = -1;
+        const reader: ByteReader = {
+          available: () => input.available(),
+          readBytes: (count: number) =>
+            Uint8Array.from(binaryStream.readByteArray(count)),
+        };
 
-        try {
-          // Step 1: Read headers until we find \r\n\r\n
-          while (totalBytesRead < maxRequestSize && !headersComplete) {
-            const bytesToRead = Math.min(4096, maxRequestSize - totalBytesRead);
-            const available = input.available();
+        // Read the full request as bytes; decode once when complete.
+        const read = await readHttpRequest(reader, {
+          maxRequestSize: 1024 * 1024,
+        });
 
-            // Attempt the read even when available === 0: the converter
-            // stream buffers up to 8KB drained from the socket per fill, and
-            // input.available() only reflects un-consumed raw socket bytes —
-            // gating reads on it strands buffered data and stalls the request
-            let chunk = "";
-            try {
-              const str: { value?: string } = {};
-              converterStream.readString(available > 0 ? Math.min(bytesToRead, available) : bytesToRead, str);
-              chunk = str.value || "";
-            } catch (converterError) {
-              // NS_BASE_STREAM_WOULD_BLOCK when both the converter buffer and
-              // the socket are empty; fall back to a raw read only when the
-              // socket reports data (decode failure on a live stream)
-              try {
-                chunk = available > 0 ? sin.read(Math.min(bytesToRead, available)) : "";
-              } catch {
-                chunk = "";
-              }
-            }
+        const headerText = read.headerText;
+        const contentLength = read.contentLength;
+        const totalBytesRead = read.totalBytesRead;
 
-            if (!chunk) {
-              if (available === 0) {
-                waitAttempts++;
-                if (waitAttempts > maxWaitAttempts) {
-                  ztoolkit.log(`[HttpServer] Timeout waiting for headers after ${waitAttempts} attempts, TotalBytes: ${totalBytesRead}`, "warn");
-                  break;
-                }
-                await new Promise((resolve) => setTimeout(resolve, 10));
-                continue;
-              }
-              // Socket reported data but the read returned nothing - EOF
-              break;
-            }
-
-            waitAttempts = 0;
-            requestText += chunk;
-            totalBytesRead += chunk.length;
-
-            // Check if headers are complete
-            bodyStartIndex = requestText.indexOf("\r\n\r\n");
-            if (bodyStartIndex !== -1) {
-              headersComplete = true;
-              // Parse Content-Length from headers
-              const headersSection = requestText.substring(0, bodyStartIndex);
-              const contentLengthMatch = headersSection.match(/Content-Length:\s*(\d+)/i);
-              if (contentLengthMatch) {
-                contentLength = parseInt(contentLengthMatch[1], 10);
-              }
-            }
-          }
-
-          // Step 2: Read body based on Content-Length (for POST requests)
-          if (headersComplete && contentLength > 0) {
-            const bodyStart = bodyStartIndex + 4; // Skip \r\n\r\n
-            // Content-Length is byte-denominated: compare UTF-8 byte counts,
-            // not UTF-16 char counts, or multibyte (CJK) bodies never satisfy
-            // the comparison and stall here until the wait timeout
-            let bodyBytesRead = getByteLength(requestText.substring(bodyStart));
-
-            ztoolkit.log(`[HttpServer] Reading body: Content-Length=${contentLength}, current=${bodyBytesRead}, remaining=${contentLength - bodyBytesRead}`);
-
-            waitAttempts = 0; // Reset wait counter for body reading
-            while (bodyBytesRead < contentLength) {
-              const available = input.available();
-              const budget = Math.min(8192, contentLength - bodyBytesRead);
-
-              // Attempt the read even when available === 0: body bytes may be
-              // sitting in the converter's internal buffer, drained from the
-              // socket during the header read (see header loop note)
-              let chunk = "";
-              try {
-                const str: { value?: string } = {};
-                converterStream.readString(available > 0 ? Math.min(budget, available) : budget, str);
-                chunk = str.value || "";
-              } catch (converterError) {
-                try {
-                  chunk = available > 0 ? sin.read(Math.min(budget, available)) : "";
-                } catch {
-                  chunk = "";
-                }
-              }
-
-              if (!chunk) {
-                if (available === 0) {
-                  waitAttempts++;
-                  if (waitAttempts > maxWaitAttempts) {
-                    ztoolkit.log(`[HttpServer] Timeout waiting for body after ${waitAttempts} attempts`, "warn");
-                    break;
-                  }
-                  await new Promise((resolve) => setTimeout(resolve, 10));
-                  continue;
-                }
-                // Socket reported data but the read returned nothing - EOF
-                break;
-              }
-
-              waitAttempts = 0;
-              requestText += chunk;
-              const chunkBytes = getByteLength(chunk);
-              bodyBytesRead += chunkBytes;
-              totalBytesRead += chunkBytes;
-            }
-          }
-        } catch (readError) {
+        if (!read.complete) {
           ztoolkit.log(
-            `[HttpServer] Error reading request: ${readError}, BytesRead: ${totalBytesRead}, InputStream available: ${input?.available ? input.available() : 'N/A'}`,
-            "error",
-          );
-          requestText = requestText || "INVALID_REQUEST";
-        }
-
-        ztoolkit.log(`[HttpServer] Total bytes read: ${totalBytesRead}, request text length: ${requestText.length}`);
-
-        try {
-          if (converterStream) converterStream.close();
-        } catch (e) {
-          ztoolkit.log(
-            `[HttpServer] Error closing converter stream: ${e}`,
-            "error",
+            `[HttpServer] Incomplete request (${read.incompleteReason}): BytesRead=${totalBytesRead}, Content-Length=${contentLength}`,
+            "warn",
           );
         }
 
-        if (sin) sin.close();
+        if (read.trailingBytes > 0) {
+          ztoolkit.log(
+            `[HttpServer] Read ${read.trailingBytes} byte(s) beyond this request body; ignoring (connection is not reused)`,
+            "warn",
+          );
+        }
+
+        ztoolkit.log(
+          `[HttpServer] Total bytes read: ${totalBytesRead}, header bytes: ${getByteLength(headerText)}, body bytes: ${contentLength}`,
+        );
 
         // Handle empty connections (likely health checks or probes)
-        if (totalBytesRead === 0 && requestText.length === 0) {
+        if (totalBytesRead === 0 && headerText.length === 0) {
           ztoolkit.log(
             `[HttpServer] Empty connection detected - likely health check/probe. Closing gracefully.`,
             "info",
@@ -485,15 +309,47 @@ export class HttpServer {
           return; // Gracefully close without sending error response
         }
 
-        const requestLine = requestText.split("\r\n")[0];
+        // A body that never reached Content-Length must not be handed to the
+        // parser: that yields a misleading "Parse error" for what is actually
+        // a truncated read. Fail loudly instead.
+        if (!read.complete && read.incompleteReason === "body-truncated") {
+          const bodyBytes = read.bodyBytesRead;
+          ztoolkit.log(
+            `[HttpServer] Request body incomplete (${bodyBytes}/${contentLength} bytes) - returning 400 rather than parsing a truncated body`,
+            "error",
+          );
+          try {
+            const truncatedBody = JSON.stringify({
+              error: "Incomplete request body",
+              expected: contentLength,
+              received: bodyBytes,
+            });
+            const truncatedHeaders = this.buildHttpHeaders(
+              {
+                status: 400,
+                statusText: "Bad Request",
+                headers: { "Content-Type": "application/json; charset=utf-8" },
+              },
+              false,
+            ) + `Content-Length: ${getByteLength(truncatedBody)}\r\n\r\n`;
+            output.write(truncatedHeaders, truncatedHeaders.length);
+            writeStringToStream(output, truncatedBody);
+            output.flush();
+          } catch (e) {
+            ztoolkit.log(`[HttpServer] Error sending 400 for truncated body: ${e}`, "error");
+          }
+          return;
+        }
+
+        const requestLine = headerText.split("\r\n")[0];
         ztoolkit.log(
-          `[HttpServer] Received request: ${requestLine} (${requestText.length} bytes)`,
+          `[HttpServer] Received request: ${requestLine} (${totalBytesRead} bytes)`,
         );
 
         // 验证请求格式
         if (!requestLine || !requestLine.includes("HTTP/")) {
           ztoolkit.log(
-            `[HttpServer] Invalid request format - RequestLine: "${requestLine || '<empty>'}", TotalBytes: ${totalBytesRead}, RequestLength: ${requestText.length}, RequestPreview: "${requestText.substring(0, 100).replace(/\r?\n/g, '\\n')}"`,
+            `[HttpServer] Invalid request format - RequestLine: "${requestLine || '<empty>'}", TotalBytes: ${totalBytesRead}, HeaderLength: ${headerText.length}, RequestPreview: "${headerText.substring(0, 100).replace(/\r?\n/g, '\\n')}"`,
             "error",
           );
           try {
@@ -528,33 +384,15 @@ export class HttpServer {
           const query = new URLSearchParams(url.search);
           const path = url.pathname;
           
-          // 提取POST请求的body
-          let requestBody = "";
-          if (method === "POST") {
-            const bodyStart = requestText.indexOf("\r\n\r\n");
-            if (bodyStart !== -1) {
-              const rawBody = requestText.substring(bodyStart + 4);
+          // The body was already framed at exactly Content-Length bytes and
+          // UTF-8 decoded once, on a complete buffer.
+          const requestBody = method === "POST" ? read.body : "";
 
-              // Only consume the current request body. Extra bytes may belong to
-              // a pipelined next request on the same socket.
-              if (contentLength > 0) {
-                requestBody = sliceByUtf8Bytes(rawBody, contentLength);
-                const rawBodyBytes = getByteLength(rawBody);
-                if (rawBodyBytes > contentLength) {
-                  ztoolkit.log(
-                    `[HttpServer] Detected trailing bytes after request body (${rawBodyBytes - contentLength} bytes), ignoring extra data for this request`,
-                    "warn",
-                  );
-                }
-              } else {
-                requestBody = rawBody;
-              }
-            }
-          }
-
-          // Extract existing session ID or create new one for MCP requests
+          // Extract existing session ID or create new one for MCP requests.
+          // Matched against headers only - a body must never be able to
+          // supply a header value.
           let sessionId: string | undefined;
-          const mcpSessionHeader = requestText.match(/Mcp-Session-Id:\s*([^\r\n]+)/i);
+          const mcpSessionHeader = headerText.match(/Mcp-Session-Id:\s*([^\r\n]+)/i);
           
           if (path === "/mcp" || (path.startsWith("/mcp/") && !path.includes(".well-known"))) {
             if (mcpSessionHeader && mcpSessionHeader[1]) {
@@ -572,7 +410,7 @@ export class HttpServer {
           }
 
           // Determine if connection should be kept alive
-          const keepAlive = this.shouldKeepAlive(requestText, path);
+          const keepAlive = this.shouldKeepAlive(headerText, path);
           ztoolkit.log(`[HttpServer] Keep-alive for ${path}: ${keepAlive}`);
 
           let result;

--- a/zotero-mcp-plugin/test/httpRequestReader.test.ts
+++ b/zotero-mcp-plugin/test/httpRequestReader.test.ts
@@ -1,0 +1,318 @@
+import { expect } from "chai";
+import {
+  readHttpRequest,
+  type ByteReader,
+} from "../src/modules/httpRequestReader.ts";
+
+const encoder = new TextEncoder();
+
+/**
+ * Fake socket that hands out a byte buffer in caller-controlled slices,
+ * so a test can place a chunk boundary anywhere - including inside a
+ * multibyte UTF-8 sequence, which is what the real bug depended on.
+ */
+class FakeReader implements ByteReader {
+  offset = 0;
+  stallsLeft = 0;
+  bytes: Uint8Array;
+  chunkSize: number;
+  stallEvery: number;
+
+  constructor(bytes: Uint8Array, chunkSize: number, stallEvery = 0) {
+    this.bytes = bytes;
+    this.chunkSize = chunkSize;
+    this.stallEvery = stallEvery;
+  }
+
+  available(): number {
+    // Simulate a socket that has not yet received the next segment.
+    if (this.stallEvery > 0 && this.stallsLeft > 0) {
+      this.stallsLeft--;
+      return 0;
+    }
+    const remaining = this.bytes.length - this.offset;
+    return Math.min(remaining, this.chunkSize);
+  }
+
+  readBytes(count: number): Uint8Array {
+    const end = Math.min(this.offset + count, this.bytes.length);
+    const out = this.bytes.subarray(this.offset, end);
+    this.offset = end;
+    if (this.stallEvery > 0) this.stallsLeft = this.stallEvery;
+    return out;
+  }
+}
+
+function buildRequest(body: string, path = "/mcp"): Uint8Array {
+  const bodyBytes = encoder.encode(body);
+  const head = encoder.encode(
+    `POST ${path} HTTP/1.1\r\n` +
+      `Host: 127.0.0.1:23120\r\n` +
+      `Content-Type: application/json\r\n` +
+      `Content-Length: ${bodyBytes.length}\r\n` +
+      `\r\n`,
+  );
+  const out = new Uint8Array(head.length + bodyBytes.length);
+  out.set(head, 0);
+  out.set(bodyBytes, head.length);
+  return out;
+}
+
+/**
+ * Delivers the header block, then reports an empty socket for a while, then
+ * delivers the body. This is the exact shape that reproduced the v1.5.0
+ * corruption 100% of the time: it forces the body read loop to execute
+ * rather than letting the header-phase read swallow the whole request.
+ */
+class SplitSegmentReader implements ByteReader {
+  head: Uint8Array;
+  body: Uint8Array;
+  offset = 0;
+  gap: number;
+
+  constructor(head: Uint8Array, body: Uint8Array, gap = 3) {
+    this.head = head;
+    this.body = body;
+    this.gap = gap;
+  }
+
+  available(): number {
+    if (this.offset < this.head.length) return this.head.length - this.offset;
+    if (this.gap > 0) {
+      this.gap--;
+      return 0; // body segment has not arrived yet
+    }
+    return this.head.length + this.body.length - this.offset;
+  }
+
+  readBytes(count: number): Uint8Array {
+    const all = new Uint8Array(this.head.length + this.body.length);
+    all.set(this.head, 0);
+    all.set(this.body, this.head.length);
+    const end = Math.min(this.offset + count, all.length);
+    const out = all.slice(this.offset, end);
+    this.offset = end;
+    return out;
+  }
+}
+
+const noSleep = () => Promise.resolve();
+
+// The regression: an accented body corrupted ~50% of the time depending
+// on where TCP happened to split the stream.
+const ACCENTED_BODY = JSON.stringify({
+  method: "tools/call",
+  params: {
+    name: "create_collection",
+    arguments: { name: "Café Théorie littéraire — révisée" },
+  },
+});
+
+describe("readHttpRequest", function () {
+  describe("body integrity across chunk boundaries", function () {
+    it("round-trips a non-ASCII body at every chunk size", async function () {
+      // 1 byte at a time guarantees a boundary inside every multibyte sequence.
+      for (const chunkSize of [1, 2, 3, 5, 17, 64, 4096]) {
+        const raw = buildRequest(ACCENTED_BODY);
+        const result = await readHttpRequest(new FakeReader(raw, chunkSize), {
+          sleep: noSleep,
+        });
+
+        expect(result.complete, `chunk ${chunkSize}`).to.equal(true);
+        expect(result.body, `chunk ${chunkSize}`).to.equal(ACCENTED_BODY);
+        expect(JSON.parse(result.body)).to.deep.equal(
+          JSON.parse(ACCENTED_BODY),
+        );
+      }
+    });
+
+    it("round-trips a body split exactly inside a multibyte sequence", async function () {
+      const body = JSON.stringify({ name: "é" });
+      const raw = buildRequest(body);
+      // Header is a fixed size; walk the boundary through the whole body.
+      for (let cut = 1; cut < raw.length; cut++) {
+        const reader = new FakeReader(raw, cut);
+        const result = await readHttpRequest(reader, { sleep: noSleep });
+        expect(result.body, `cut at ${cut}`).to.equal(body);
+      }
+    });
+
+    it("round-trips 4-byte sequences (emoji / surrogate pairs)", async function () {
+      const body = JSON.stringify({ name: "Étude 🧪🔬 données" });
+      const raw = buildRequest(body);
+      for (const chunkSize of [1, 3, 7, 4096]) {
+        const result = await readHttpRequest(new FakeReader(raw, chunkSize), {
+          sleep: noSleep,
+        });
+        expect(result.body, `chunk ${chunkSize}`).to.equal(body);
+      }
+    });
+
+    it("round-trips CJK bodies", async function () {
+      const body = JSON.stringify({ name: "文献管理集合" });
+      const raw = buildRequest(body);
+      const result = await readHttpRequest(new FakeReader(raw, 3), {
+        sleep: noSleep,
+      });
+      expect(result.body).to.equal(body);
+    });
+
+    it("round-trips a pure ASCII body (the case that always worked)", async function () {
+      const body = JSON.stringify({ name: "Literary Theory" });
+      const raw = buildRequest(body);
+      const result = await readHttpRequest(new FakeReader(raw, 1), {
+        sleep: noSleep,
+      });
+      expect(result.body).to.equal(body);
+    });
+
+    it("handles a body larger than one read budget", async function () {
+      const body = JSON.stringify({ name: "é".repeat(20000) });
+      const raw = buildRequest(body);
+      const result = await readHttpRequest(new FakeReader(raw, 1500), {
+        sleep: noSleep,
+      });
+      expect(result.complete).to.equal(true);
+      expect(result.body).to.equal(body);
+    });
+  });
+
+  describe("Content-Length accounting", function () {
+    it("measures the body in bytes, not UTF-16 code units", async function () {
+      const body = JSON.stringify({ name: "café" });
+      const raw = buildRequest(body);
+      const result = await readHttpRequest(new FakeReader(raw, 4096), {
+        sleep: noSleep,
+      });
+      // "café" is 5 chars but 6 bytes; Content-Length is byte-denominated.
+      expect(result.contentLength).to.equal(new TextEncoder().encode(body).length);
+      expect(result.contentLength).to.be.greaterThan(body.length);
+      expect(result.complete).to.equal(true);
+    });
+
+    it("does not consume bytes beyond Content-Length", async function () {
+      const first = buildRequest(JSON.stringify({ n: "é" }));
+      const second = buildRequest(JSON.stringify({ n: "à" }));
+      const pipelined = new Uint8Array(first.length + second.length);
+      pipelined.set(first, 0);
+      pipelined.set(second, first.length);
+
+      const result = await readHttpRequest(new FakeReader(pipelined, 4096), {
+        sleep: noSleep,
+      });
+      // Read-ahead into the next request is allowed, but the body must be cut
+      // exactly at Content-Length and the overshoot reported, never folded in.
+      expect(result.body).to.equal(JSON.stringify({ n: "é" }));
+      expect(result.trailingBytes).to.equal(second.length);
+      expect(result.complete).to.equal(true);
+    });
+
+    it("stops reading at Content-Length once the body length is known", async function () {
+      // Small chunks mean the header phase cannot overshoot; the body phase
+      // must then stop dead on the boundary rather than draining the socket.
+      const first = buildRequest(JSON.stringify({ n: "é" }));
+      const second = buildRequest(JSON.stringify({ n: "à" }));
+      const pipelined = new Uint8Array(first.length + second.length);
+      pipelined.set(first, 0);
+      pipelined.set(second, first.length);
+
+      const result = await readHttpRequest(new FakeReader(pipelined, 8), {
+        sleep: noSleep,
+      });
+      expect(result.body).to.equal(JSON.stringify({ n: "é" }));
+      expect(result.trailingBytes).to.equal(0);
+      expect(result.totalBytesRead).to.equal(first.length);
+    });
+  });
+
+  describe("body in its own TCP segment (the v1.5.0 repro)", function () {
+    it("round-trips French, CJK and emoji when the body arrives separately", async function () {
+      const payloads = [
+        JSON.stringify({ name: "Café Théorie littéraire — révisée" }),
+        JSON.stringify({ name: "文献管理集合 中文测试 学术研究" }),
+        JSON.stringify({ name: "Étude 🧪 données" }),
+        JSON.stringify({ name: "Literary Theory" }),
+      ];
+
+      for (const payload of payloads) {
+        const bodyBytes = encoder.encode(payload);
+        const head = encoder.encode(
+          `POST /mcp HTTP/1.1\r\nHost: 127.0.0.1:23120\r\n` +
+            `Content-Type: application/json\r\n` +
+            `Content-Length: ${bodyBytes.length}\r\n\r\n`,
+        );
+        const result = await readHttpRequest(
+          new SplitSegmentReader(head, bodyBytes),
+          { sleep: noSleep },
+        );
+
+        expect(result.complete, payload).to.equal(true);
+        expect(result.body, payload).to.equal(payload);
+        expect(() => JSON.parse(result.body)).to.not.throw();
+      }
+    });
+  });
+
+  describe("stalled sockets", function () {
+    it("waits out a socket that reports no data between segments", async function () {
+      const body = JSON.stringify({ name: "Théorie" });
+      const raw = buildRequest(body);
+      const result = await readHttpRequest(new FakeReader(raw, 4, 2), {
+        sleep: noSleep,
+      });
+      expect(result.complete).to.equal(true);
+      expect(result.body).to.equal(body);
+    });
+
+    it("reports incompleteness instead of returning a truncated body", async function () {
+      const body = JSON.stringify({ name: "Théorie" });
+      const raw = buildRequest(body);
+      // Drop the last 3 bytes: Content-Length can never be satisfied.
+      const truncated = raw.subarray(0, raw.length - 3);
+      const result = await readHttpRequest(new FakeReader(truncated, 4096), {
+        sleep: noSleep,
+        maxWaitAttempts: 3,
+      });
+      expect(result.complete).to.equal(false);
+      expect(result.incompleteReason).to.equal("body-truncated");
+      // The caller needs the real figure to report 400 instead of parsing.
+      expect(result.bodyBytesRead).to.be.lessThan(result.contentLength);
+      expect(result.bodyBytesRead).to.equal(result.contentLength - 3);
+    });
+  });
+
+  describe("header parsing", function () {
+    it("exposes headers separately from the body", async function () {
+      const body = JSON.stringify({ name: "Mcp-Session-Id: spoofed" });
+      const raw = buildRequest(body);
+      const result = await readHttpRequest(new FakeReader(raw, 4096), {
+        sleep: noSleep,
+      });
+      // A header lookup must not be satisfiable by body content.
+      expect(result.headerText).to.not.contain("spoofed");
+      expect(result.headerText.split("\r\n")[0]).to.equal("POST /mcp HTTP/1.1");
+    });
+
+    it("handles a GET with no body", async function () {
+      const raw = encoder.encode(
+        "GET /status HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
+      );
+      const result = await readHttpRequest(new FakeReader(raw, 4096), {
+        sleep: noSleep,
+      });
+      expect(result.complete).to.equal(true);
+      expect(result.contentLength).to.equal(0);
+      expect(result.body).to.equal("");
+    });
+
+    it("returns empty for a connection that sends nothing", async function () {
+      const result = await readHttpRequest(
+        new FakeReader(new Uint8Array(0), 4096),
+        { sleep: noSleep, maxWaitAttempts: 2 },
+      );
+      expect(result.totalBytesRead).to.equal(0);
+      expect(result.headerText).to.equal("");
+      expect(result.complete).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
The socket read path decoded incrementally through nsIConverterInputStream with a raw nsIScriptableInputStream fallback on the same stream. When the fallback fired it appended raw bytes as latin1 characters, so "é" became "Ã©". getByteLength() then over-counted the mojibake, the body loop exited early, and the body was truncated mid-token - JSON.parse threw and the server answered 400 with -32700.

The corrupting loop only runs when the body arrives in a separate TCP segment from the headers, which is why it looked intermittent. Forcing that split reproduces it 100% of the time; CJK is affected worse than Latin-1 accents, not better.

Read the request as raw bytes via nsIBinaryInputStream, locate the CRLFCRLF terminator by scanning bytes, frame the body at exactly Content-Length, and UTF-8 decode once on a complete buffer. Framing logic moves to a new httpRequestReader module free of XPCOM globals so it is unit-testable - this path has been patched three times without ever having had a test.

Fixes #97