### PR TITLE
feat: add add_by_identifier tool using Zotero's native identifier resolvers

### DIFF
--- a/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
+++ b/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
@@ -1097,6 +1097,11 @@ export class StreamableMCPServer {
               type: 'boolean',
               description: 'When an item already exists, also add it to the target collection. This is the only way this tool modifies existing items (default false).'
             },
+            titleDuplicates: {
+              type: 'string',
+              enum: ['flag', 'skip', 'off'],
+              description: "How to handle an imported item whose title matches an item already in the library — this catches a preprint arriving next to its published version, which identifier matching cannot see. 'flag' (default) keeps the import and reports possibleDuplicateOf; 'skip' moves the freshly imported item to the trash and reports duplicate_trashed; 'off' disables the check."
+            },
             dryRun: {
               type: 'boolean',
               description: 'Only report how Zotero parses each identifier; writes nothing (default false).'
@@ -2669,6 +2674,7 @@ export class StreamableMCPServer {
       skipExisting: args.skipExisting !== false,
       fileExisting: args.fileExisting === true,
       dryRun: args.dryRun === true,
+      titleDuplicates: args.titleDuplicates || 'flag',
       delayMs: typeof args.delayMs === 'number' ? args.delayMs : 500
     };
 
@@ -2804,13 +2810,76 @@ export class StreamableMCPServer {
     }
 
     ztoolkit.log(`[StreamableMCP] add_by_identifier imported ${newItems[0].key} for ${parsed}`);
+
+    // A preprint and its published version share no identifier, so the check
+    // above cannot see them as the same work. The title is only known after
+    // resolution, hence this second pass.
+    let duplicatesOf: any[] = [];
+    if (opts.titleDuplicates !== 'off') {
+      duplicatesOf = await this.findItemsByTitle(opts.libraryID, newItems[0]);
+    }
+
+    if (duplicatesOf.length && opts.titleDuplicates === 'skip') {
+      const imported = newItems[0];
+      imported.deleted = true; // to the trash, not erased
+      await imported.saveTx();
+      return {
+        input,
+        identifier: parsed,
+        status: 'duplicate_trashed',
+        trashedItemKey: imported.key,
+        duplicateOf: duplicatesOf,
+        item: this.summarizeIdentifierItem(imported)
+      };
+    }
+
     return {
       input,
       identifier: parsed,
       status: 'imported',
       item: this.summarizeIdentifierItem(newItems[0]),
+      ...(duplicatesOf.length ? { possibleDuplicateOf: duplicatesOf } : {}),
       extraItems: newItems.slice(1).map((i: any) => this.summarizeIdentifierItem(i))
     };
+  }
+
+  /**
+   * Find other regular items in the library whose title normalizes to the same
+   * string. Deliberately exact-after-normalization rather than fuzzy: catching
+   * "preprint vs published version" is worth it, guessing is not.
+   */
+  private async findItemsByTitle(libraryID: number, item: any): Promise<any[]> {
+    const normalize = (value: string) => String(value || '')
+      .toLowerCase()
+      .replace(/[^a-z0-9一-鿿]+/g, ' ')
+      .trim();
+
+    const title = item.getField('title');
+    const target = normalize(title);
+    if (target.length < 8) return [];
+
+    // Cheap candidate filter, then compare normalized titles in full: a
+    // 'contains' search cannot survive punctuation differences on its own.
+    const tokens = target.split(' ').filter((t: string) => t.length >= 5);
+    const probe = tokens.sort((a: string, b: string) => b.length - a.length)[0] || target.slice(0, 20);
+
+    try {
+      const search = new Zotero.Search();
+      (search as any).libraryID = libraryID;
+      search.addCondition('noChildren', 'true');
+      search.addCondition('title', 'contains', probe);
+      const ids = await search.search();
+      if (!ids || !ids.length) return [];
+
+      const candidates = await Zotero.Items.getAsync(ids);
+      return candidates
+        .filter((c: any) => c.id !== item.id && c.isRegularItem() && !c.deleted)
+        .filter((c: any) => normalize(c.getField('title')) === target)
+        .map((c: any) => this.summarizeIdentifierItem(c));
+    } catch (error) {
+      ztoolkit.log(`[StreamableMCP] add_by_identifier title duplicate check failed: ${error}`, 'warn');
+      return [];
+    }
   }
 
   /**

--- a/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
+++ b/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
@@ -1065,6 +1065,56 @@ export class StreamableMCPServer {
           },
           required: ['action']
         }
+      },
+      {
+        name: 'add_by_identifier',
+        description: "Add items to Zotero by identifier (DOI, arXiv ID, ISBN, PMID, or ADS bibcode) using Zotero's own metadata resolvers — the same pipeline as the 'Add Item by Identifier' magic-wand button. Item type, DOI, venue, authors and date all come from Zotero's translators, so prefer this over write_item whenever an identifier is available: write_item requires guessing metadata by hand, which produces wrong item types. Batches larger than 3 run as a background job; call again with jobID to poll.",
+        inputSchema: {
+          type: 'object',
+          properties: {
+            identifiers: {
+              type: 'array',
+              items: { type: 'string' },
+              description: "One identifier per entry, e.g. '10.1109/ICRA48891.2023.10160731', 'arXiv:2304.00464', '9780262035613', 'PMID: 31452104'. Prefix bare arXiv numbers with 'arXiv:'. Each entry is parsed on its own, so identifier types can be mixed freely."
+            },
+            collectionKey: {
+              type: 'string',
+              description: '8-character key of the collection to file new items into. Omit to save to the library root.'
+            },
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
+            saveAttachments: {
+              type: 'boolean',
+              description: 'Fetch open-access PDFs along with the metadata (default true).'
+            },
+            skipExisting: {
+              type: 'boolean',
+              description: 'Skip identifiers already present in the library instead of creating duplicates (default true).'
+            },
+            fileExisting: {
+              type: 'boolean',
+              description: 'When an item already exists, also add it to the target collection. This is the only way this tool modifies existing items (default false).'
+            },
+            dryRun: {
+              type: 'boolean',
+              description: 'Only report how Zotero parses each identifier; writes nothing (default false).'
+            },
+            delayMs: {
+              type: 'number',
+              description: 'Pause between lookups in milliseconds, to be polite to upstream APIs (default 500).'
+            },
+            async: {
+              type: 'boolean',
+              description: 'Force background-job mode even for small batches.'
+            },
+            jobID: {
+              type: 'string',
+              description: 'Poll a previously started background job instead of starting a new import.'
+            }
+          }
+        }
       }
     ];
 
@@ -1078,7 +1128,7 @@ export class StreamableMCPServer {
     // Filter out write tools if write operations are disabled (default: disabled)
     const writeEnabled = Zotero.Prefs.get('extensions.zotero.zotero-mcp-plugin.write.enabled', true);
     const writeToolNames = new Set([
-      'write_note', 'write_tag', 'write_metadata', 'write_item',
+      'write_note', 'write_tag', 'write_metadata', 'write_item', 'add_by_identifier',
     ]);
     const finalTools = writeEnabled === true
       ? filteredTools
@@ -1325,6 +1375,23 @@ export class StreamableMCPServer {
             throw new Error('action is required');
           }
           result = await this.callWriteItem(args);
+          break;
+        }
+
+        case 'add_by_identifier': {
+          // Polling a job and dry runs write nothing, so they stay available
+          // even when write operations are disabled.
+          const isReadOnlyCall = args?.jobID || args?.dryRun === true;
+          if (!isReadOnlyCall) {
+            const writeEnabled5 = Zotero.Prefs.get('extensions.zotero.zotero-mcp-plugin.write.enabled', true);
+            if (writeEnabled5 !== true) {
+              throw new Error('Write operations are currently disabled. Please go to Zotero → Tools → Add-ons → Zotero MCP Plugin → Preferences, and enable "Write Operations" to use this feature.');
+            }
+          }
+          if (!args?.jobID && !args?.identifiers && !args?.identifier) {
+            throw new Error('identifiers is required (an array of DOI / arXiv / ISBN / PMID / ADS strings)');
+          }
+          result = await this.callAddByIdentifier(args);
           break;
         }
 
@@ -2539,6 +2606,322 @@ export class StreamableMCPServer {
         success: false,
         error: String(error)
       };
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // add_by_identifier
+  // ---------------------------------------------------------------------
+
+  /** Background jobs for add_by_identifier, keyed by job ID. */
+  private static identifierJobs = new Map<string, any>();
+  private static identifierJobSeq = 0;
+  private static readonly MAX_IDENTIFIERS_PER_CALL = 200;
+  private static readonly MAX_SYNC_IDENTIFIERS = 3;
+
+  /**
+   * Resolve DOI / arXiv / ISBN / PMID / ADS identifiers through Zotero's own
+   * search translators and save the resulting items.
+   *
+   * Mirrors chrome/content/zotero/lookup.js (the "Add Item by Identifier"
+   * button): extractIdentifiers → Zotero.Translate.Search → setIdentifier →
+   * getTranslators → setTranslator → translate(). Item types and metadata are
+   * therefore exactly what Zotero itself produces; nothing is invented here.
+   */
+  private async callAddByIdentifier(args: any): Promise<any> {
+    // Polling an existing job
+    if (args?.jobID) {
+      const job = StreamableMCPServer.identifierJobs.get(args.jobID);
+      if (!job) {
+        throw new Error(`Job not found: ${args.jobID}. Jobs are kept only for the current Zotero session.`);
+      }
+      return this.summarizeIdentifierJob(job);
+    }
+
+    const raw = args.identifiers ?? args.identifier;
+    const inputs = (Array.isArray(raw) ? raw : String(raw).split(/[\r\n]+/))
+      .map((s: any) => String(s).trim())
+      .filter((s: string) => s.length > 0);
+
+    if (!inputs.length) {
+      throw new Error('No identifiers provided');
+    }
+    if (inputs.length > StreamableMCPServer.MAX_IDENTIFIERS_PER_CALL) {
+      throw new Error(`Too many identifiers (${inputs.length}). Send at most ${StreamableMCPServer.MAX_IDENTIFIERS_PER_CALL} per call.`);
+    }
+
+    const libraryID = args.libraryID ?? Zotero.Libraries.userLibraryID;
+    let collections: number[] | false = false;
+    let collectionName: string | null = null;
+    if (args.collectionKey) {
+      const collection = Zotero.Collections.getByLibraryAndKey(libraryID, args.collectionKey);
+      if (!collection) {
+        throw new Error(`Collection not found in library ${libraryID}: ${args.collectionKey}`);
+      }
+      collections = [(collection as any).id];
+      collectionName = (collection as any).name;
+    }
+
+    const opts = {
+      libraryID,
+      collections,
+      saveAttachments: args.saveAttachments !== false,
+      skipExisting: args.skipExisting !== false,
+      fileExisting: args.fileExisting === true,
+      dryRun: args.dryRun === true,
+      delayMs: typeof args.delayMs === 'number' ? args.delayMs : 500
+    };
+
+    const job: any = {
+      id: `identifier-job-${++StreamableMCPServer.identifierJobSeq}`,
+      state: 'running',
+      total: inputs.length,
+      done: 0,
+      results: [],
+      startedAt: new Date().toISOString(),
+      finishedAt: null,
+      target: { libraryID, collectionKey: args.collectionKey || null, collectionName }
+    };
+    StreamableMCPServer.identifierJobs.set(job.id, job);
+    this.pruneIdentifierJobs();
+
+    const run = this.runIdentifierJob(job, inputs, opts);
+
+    // Long batches would blow past the MCP keep-alive window, so anything
+    // bigger than a couple of lookups is handed back as a pollable job.
+    const runAsync = args.async === true
+      || (!opts.dryRun && inputs.length > StreamableMCPServer.MAX_SYNC_IDENTIFIERS);
+
+    if (!runAsync) {
+      await run;
+      return this.summarizeIdentifierJob(job);
+    }
+
+    return {
+      success: true,
+      data: {
+        jobID: job.id,
+        state: job.state,
+        total: job.total,
+        target: job.target
+      },
+      metadata: {
+        extractedAt: new Date().toISOString(),
+        message: `Started background import of ${job.total} identifier(s). Poll with add_by_identifier {"jobID": "${job.id}"}.`
+      }
+    };
+  }
+
+  private async runIdentifierJob(job: any, inputs: string[], opts: any): Promise<void> {
+    try {
+      for (const input of inputs) {
+        try {
+          job.results.push(await this.importOneIdentifier(input, opts));
+        } catch (error) {
+          ztoolkit.log(`[StreamableMCP] add_by_identifier failed for "${input}": ${error}`, 'error');
+          job.results.push({ input, status: 'error', error: String(error) });
+        }
+        job.done++;
+        if (opts.delayMs > 0 && job.done < job.total) {
+          await new Promise(resolve => setTimeout(resolve, opts.delayMs));
+        }
+      }
+      job.state = 'done';
+    } catch (error) {
+      job.state = 'error';
+      job.error = String(error);
+    } finally {
+      job.finishedAt = new Date().toISOString();
+    }
+  }
+
+  private async importOneIdentifier(input: string, opts: any): Promise<any> {
+    const identifiers = (Zotero.Utilities as any).extractIdentifiers(input);
+    if (!identifiers.length) {
+      return { input, status: 'error', error: 'NO_IDENTIFIER_FOUND' };
+    }
+    if (identifiers.length > 1) {
+      // One entry should mean one item; anything else is ambiguous input.
+      return {
+        input,
+        status: 'error',
+        error: 'AMBIGUOUS_INPUT',
+        parsed: identifiers.map((id: any) => this.describeIdentifier(id))
+      };
+    }
+
+    const identifier = identifiers[0];
+    const parsed = this.describeIdentifier(identifier);
+
+    if (opts.dryRun) {
+      return { input, status: 'parsed', identifier: parsed };
+    }
+
+    if (opts.skipExisting) {
+      const existing = await this.findItemByIdentifier(opts.libraryID, identifier);
+      if (existing) {
+        let addedToCollection = false;
+        // The only path in this tool that touches an item already in the
+        // library, so it has to be asked for explicitly.
+        if (opts.fileExisting && opts.collections) {
+          const current = existing.getCollections();
+          const missing = opts.collections.filter((cid: number) => !current.includes(cid));
+          if (missing.length) {
+            for (const cid of missing) {
+              existing.addToCollection(cid);
+            }
+            await existing.saveTx();
+            addedToCollection = true;
+          }
+        }
+        return {
+          input,
+          identifier: parsed,
+          status: 'exists',
+          addedToCollection,
+          item: this.summarizeIdentifierItem(existing)
+        };
+      }
+    }
+
+    const translate = new (Zotero as any).Translate.Search();
+    translate.setIdentifier(identifier);
+    // Be lenient about translators, exactly like lookup.js
+    const translators = await translate.getTranslators();
+    if (!translators || !translators.length) {
+      return { input, identifier: parsed, status: 'error', error: 'NO_TRANSLATOR' };
+    }
+    translate.setTranslator(translators);
+
+    const newItems = await translate.translate({
+      libraryID: opts.libraryID,
+      collections: opts.collections,
+      saveAttachments: opts.saveAttachments
+    });
+
+    if (!newItems || !newItems.length) {
+      return { input, identifier: parsed, status: 'error', error: 'NO_ITEM_RETURNED' };
+    }
+
+    ztoolkit.log(`[StreamableMCP] add_by_identifier imported ${newItems[0].key} for ${parsed}`);
+    return {
+      input,
+      identifier: parsed,
+      status: 'imported',
+      item: this.summarizeIdentifierItem(newItems[0]),
+      extraItems: newItems.slice(1).map((i: any) => this.summarizeIdentifierItem(i))
+    };
+  }
+
+  /**
+   * Look for an item already in the library carrying this identifier, so that
+   * repeated calls do not pile up duplicates.
+   */
+  private async findItemByIdentifier(libraryID: number, identifier: any): Promise<any> {
+    const conditions: Array<[string, string, string]> = [];
+    if (identifier.DOI) conditions.push(['DOI', 'is', identifier.DOI]);
+    if (identifier.ISBN) conditions.push(['ISBN', 'is', identifier.ISBN]);
+    if (identifier.arXiv) {
+      conditions.push(['extra', 'contains', `arXiv:${identifier.arXiv}`]);
+      conditions.push(['url', 'contains', `arxiv.org/abs/${identifier.arXiv}`]);
+    }
+    if (identifier.PMID && !Array.isArray(identifier.PMID)) {
+      conditions.push(['extra', 'contains', `PMID: ${identifier.PMID}`]);
+    }
+    if (identifier.adsBibcode) conditions.push(['extra', 'contains', identifier.adsBibcode]);
+
+    for (const [field, operator, value] of conditions) {
+      try {
+        const search = new Zotero.Search();
+        // Settable at runtime; zotero-types marks it read-only.
+        (search as any).libraryID = libraryID;
+        search.addCondition('noChildren', 'true');
+        search.addCondition(field as any, operator as any, value);
+        const ids = await search.search();
+        if (ids && ids.length) {
+          const items = await Zotero.Items.getAsync(ids);
+          const item = items.find((i: any) => i.isRegularItem());
+          if (item) return item;
+        }
+      } catch (error) {
+        ztoolkit.log(`[StreamableMCP] add_by_identifier duplicate check failed on ${field}: ${error}`, 'warn');
+      }
+    }
+    return null;
+  }
+
+  private describeIdentifier(identifier: any): string {
+    if (!identifier) return '';
+    for (const key of ['DOI', 'arXiv', 'ISBN', 'PMID', 'adsBibcode']) {
+      const value = identifier[key];
+      if (value) return `${key}:${Array.isArray(value) ? value.join(',') : value}`;
+    }
+    return JSON.stringify(identifier);
+  }
+
+  private summarizeIdentifierItem(item: any): any {
+    const summary: any = {
+      itemKey: item.key,
+      itemType: Zotero.ItemTypes.getName(item.itemTypeID),
+      title: item.getField('title'),
+      date: item.getField('date'),
+      DOI: item.getField('DOI') || '',
+      url: item.getField('url') || '',
+      extra: item.getField('extra') || ''
+    };
+    for (const field of ['publicationTitle', 'proceedingsTitle', 'repository', 'publisher']) {
+      try {
+        const value = item.getField(field);
+        if (value) {
+          summary.venue = value;
+          break;
+        }
+      } catch (error) {
+        // Field is not valid for this item type
+      }
+    }
+    return summary;
+  }
+
+  private summarizeIdentifierJob(job: any): any {
+    const counts: Record<string, number> = {};
+    const itemTypes: Record<string, number> = {};
+    for (const row of job.results) {
+      counts[row.status] = (counts[row.status] || 0) + 1;
+      if (row.item?.itemType) {
+        itemTypes[row.item.itemType] = (itemTypes[row.item.itemType] || 0) + 1;
+      }
+    }
+    return {
+      success: job.state !== 'error',
+      data: {
+        jobID: job.id,
+        state: job.state,
+        total: job.total,
+        done: job.done,
+        counts,
+        itemTypes,
+        target: job.target,
+        results: job.results
+      },
+      metadata: {
+        extractedAt: new Date().toISOString(),
+        startedAt: job.startedAt,
+        finishedAt: job.finishedAt,
+        message: job.state === 'running'
+          ? `Import in progress: ${job.done}/${job.total}. Poll again with jobID ${job.id}.`
+          : `Import ${job.state}: ${job.done}/${job.total} processed.`
+      }
+    };
+  }
+
+  /** Keep at most 20 finished jobs around. */
+  private pruneIdentifierJobs(): void {
+    const finished = Array.from(StreamableMCPServer.identifierJobs.values())
+      .filter((job: any) => job.state !== 'running');
+    if (finished.length <= 20) return;
+    for (const job of finished.slice(0, finished.length - 20)) {
+      StreamableMCPServer.identifierJobs.delete(job.id);
     }
   }
 


### PR DESCRIPTION
## Problem

There is currently no way to add an item to Zotero from an identifier. `write_item` can only create an item from fields the model types out by hand, which means the model has to guess the item type and the bibliographic details.

That guessing fails in practice. Importing 64 arXiv papers through hand-built metadata produced **31 `document`, 30 `conferencePaper`, 3 `journalArticle`, and 0 `preprint`** items, along with a wave of missing-DOI lint. Every one of those papers resolves correctly through Zotero's own resolvers — the metadata was never the problem, the bypass was.

Zotero already ships the right machinery behind the "Add Item by Identifier" magic wand, but it is only reachable from the UI. This PR exposes it as a tool.

## What this adds

`add_by_identifier` — resolve DOI / arXiv ID / ISBN / PMID / ADS bibcode through Zotero's own search translators and save the resulting items.

The core is a direct port of `chrome/content/zotero/lookup.js`:

```
Zotero.Utilities.extractIdentifiers
  → new Zotero.Translate.Search()
  → setIdentifier → getTranslators → setTranslator
  → translate({ libraryID, collections, saveAttachments })
```

Item type, DOI, venue, creators and date all come from Zotero's translators. Nothing in this code path constructs metadata.

## Design notes

**Background jobs.** The MCP keep-alive window is 30s and a batch of lookups will exceed it, so anything over 3 identifiers returns a job ID immediately and is polled with `add_by_identifier {"jobID": "..."}`. Small batches and dry runs still answer inline. Lookups are serialized with a configurable delay (default 500ms) to stay polite to upstream APIs.

**Each entry is parsed on its own.** `extractIdentifiers` resolves by type priority — if any DOI appears in a blob of text, arXiv IDs in the same blob are skipped entirely. Parsing per entry means callers can mix identifier types freely in one call.

**Duplicate handling.** Identifiers already in the library are detected by DOI / arXiv / ISBN / PMID / ADS and reported as `exists` instead of being imported again (`skipExisting`, on by default). Because a preprint and its published version share no identifier, a second pass compares the imported item's title — exact after normalization, not fuzzy — and reports `possibleDuplicateOf`. `titleDuplicates` switches that between `flag` (default), `skip` (trash the fresh import) and `off`.

**It does not modify existing items.** The only code path that writes to an item already in the library is `fileExisting`, which is off by default and only adds an existing item to the target collection. Everything else either creates new items or reports.

**Permissions.** The tool joins the existing `writeToolNames` set, so it respects `extensions.zotero.zotero-mcp-plugin.write.enabled` like every other write tool — no new permission surface. `dryRun` and job polling write nothing and stay available when write operations are disabled.

**Limits.** 200 identifiers per call, rejected explicitly rather than silently truncated. At most 20 finished jobs are retained.

## Testing

Verified against a real library (Zotero 7, ~2000 items):

| Case | Result |
| --- | --- |
| Tool registration | 27 → 28 tools |
| Mixed dry run (`arXiv:`-prefixed, bare arXiv, DOI, PMID, ISBN, garbage) | all five parsed to the right type; garbage → `NO_IDENTIFIER_FOUND`; zero writes |
| `arXiv:2210.02697` | `preprint`, DOI `10.48550/arXiv.2210.02697`, `arXiv:2210.02697 [cs.RO]`, OA PDF + snapshot fetched |
| `10.1109/TBME.2025.3575252` | `journalArticle`, venue `IEEE Transactions on Bio-Medical Engineering` |
| Same DOI again with `skipExisting` on | `exists`, matched the item already in the library, nothing created |
| Async job + polling | job returned immediately, polled to `done` |
| Duplicate hit with `fileExisting` off | `addedToCollection: false` — existing item untouched |

`tsc --noEmit` is clean.

## Not included

No version bump — I left `package.json` at 1.5.0 so this merges without conflicting with your release flow.

---

## 中文说明

**问题**：目前没有「按标识符添加条目」的工具，`write_item` 只能靠模型手填元数据、自己猜条目类型。实测用手工元数据导入 64 篇 arXiv 论文，得到 31 条 `document`、0 条 `preprint`，并触发大量缺 DOI 的告警——而这些论文用 Zotero 自己的解析器全都能正确识别。

**方案**：新增 `add_by_identifier`，复刻 Zotero 魔杖按钮的原生链路（`lookup.js`），支持 DOI / arXiv / ISBN / PMID / ADS。条目类型与元数据全部由 Zotero 的 translator 产出，代码里没有任何一处手工构造元数据。

**要点**：超过 3 条转后台 job 轮询（MCP keep-alive 只有 30 秒）；逐条解析以便混合标识符类型；按标识符查重，并额外用归一化标题捕捉「预印本 vs 发表版」；默认不修改任何已有条目；复用现有的写操作开关，不新增权限面。
