### PR TITLE
fix(write): defer slow post-commit notifications

### DIFF
--- a/zotero-mcp-plugin/src/hooks.ts
+++ b/zotero-mcp-plugin/src/hooks.ts
@@ -6,6 +6,10 @@ import { registerPrefsScripts } from "./modules/preferenceScript";
 import { createZToolkit } from "./utils/ztoolkit";
 import { MCPSettingsService } from "./modules/mcpSettingsService";
 import { registerSemanticIndexColumn, unregisterSemanticIndexColumn, refreshSemanticColumn } from "./modules/semanticIndexColumn";
+import {
+  flushNotifierCommits,
+  flushWriteOperations,
+} from "./modules/deferredNotifierCommitter";
 
 // Preference keys for semantic search settings
 const PREF_SEMANTIC_ENABLED = 'extensions.zotero.zotero-mcp-plugin.semantic.enabled';
@@ -499,11 +503,24 @@ async function onMainWindowUnload(win: Window): Promise<void> {
   ztoolkit.unregisterAll();
 }
 
-function onShutdown(): void {
+async function onShutdown(): Promise<void> {
   ztoolkit.log("[MCP Plugin] ======== SHUTDOWN START ========");
 
   // Set shutdown flag to prevent new async operations
   isShuttingDown = true;
+
+  // Stop accepting writes, then give already-committed notifier queues a
+  // bounded chance to finish while observers are still registered.
+  try {
+    if (httpServer.isServerRunning()) {
+      httpServer.stop();
+    }
+    await flushWriteOperations();
+    await flushNotifierCommits();
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    ztoolkit.log(`[MCP Plugin] Error flushing notifier queues: ${err.message}`, "error");
+  }
 
   // Clear all pending timeouts immediately
   ztoolkit.log("[MCP Plugin] [SHUTDOWN 1/7] Clearing pending timeouts...");

--- a/zotero-mcp-plugin/src/modules/apiHandlers.ts
+++ b/zotero-mcp-plugin/src/modules/apiHandlers.ts
@@ -13,6 +13,11 @@ import {
 } from "./collectionFormatter";
 import { handleSearchRequest, MCPError } from "./searchEngine";
 import { FulltextService } from "./fulltextService";
+import {
+  commitNotifierQueue,
+  createNotifierQueue,
+  notifierSaveOptions,
+} from "./deferredNotifierCommitter";
 
 declare let ztoolkit: ZToolkit;
 
@@ -1094,14 +1099,19 @@ export async function handleCreateCollection(
       collection.parentKey = body.parentCollection;
     }
 
-    await collection.saveTx();
+    const notifierQueue = createNotifierQueue();
+    await collection.saveTx(notifierSaveOptions(notifierQueue));
+    const notification = await commitNotifierQueue(notifierQueue, `create collection ${collection.key}`);
     ztoolkit.log(`[ApiHandlers] Created collection: ${collection.key} - ${collection.name}`);
 
     return {
       status: 201,
       statusText: "Created",
       headers: { "Content-Type": "application/json; charset=utf-8" },
-      body: JSON.stringify(formatCollectionBrief(collection)),
+      body: JSON.stringify({
+        ...formatCollectionBrief(collection),
+        notificationStatus: notification.status,
+      }),
     };
   } catch (e) {
     const error = e instanceof Error ? e : new Error(String(e));
@@ -1203,14 +1213,19 @@ export async function handleUpdateCollection(
       }
     }
 
-    await collection.saveTx();
+    const notifierQueue = createNotifierQueue();
+    await collection.saveTx(notifierSaveOptions(notifierQueue));
+    const notification = await commitNotifierQueue(notifierQueue, `update collection ${collectionKey}`);
     ztoolkit.log(`[ApiHandlers] Updated collection: ${collection.key} - ${collection.name}`);
 
     return {
       status: 200,
       statusText: "OK",
       headers: { "Content-Type": "application/json; charset=utf-8" },
-      body: JSON.stringify(formatCollectionBrief(collection)),
+      body: JSON.stringify({
+        ...formatCollectionBrief(collection),
+        notificationStatus: notification.status,
+      }),
     };
   } catch (e) {
     const error = e instanceof Error ? e : new Error(String(e));
@@ -1263,7 +1278,17 @@ export async function handleDeleteCollection(
     const numItems = collection.getChildItems(true).length;
     const numSubcollections = collection.getChildCollections(true).length;
 
-    await collection.eraseTx({ deleteItems: body.deleteItems ?? false });
+    let notificationStatus = "completed";
+    if (body.deleteItems) {
+      // Zotero does not propagate a custom notifier queue to descendant item
+      // trash operations, so keep the native synchronous path for this case.
+      await collection.eraseTx({ deleteItems: true });
+    } else {
+      const notifierQueue = createNotifierQueue();
+      await collection.eraseTx(notifierSaveOptions(notifierQueue));
+      const notification = await commitNotifierQueue(notifierQueue, `delete collection ${collectionKey}`);
+      notificationStatus = notification.status;
+    }
     ztoolkit.log(`[ApiHandlers] Deleted collection: ${collectionKey} - ${name}`);
 
     return {
@@ -1272,6 +1297,7 @@ export async function handleDeleteCollection(
       headers: { "Content-Type": "application/json; charset=utf-8" },
       body: JSON.stringify({
         success: true,
+        notificationStatus,
         deleted: {
           key: collectionKey,
           name,
@@ -1354,13 +1380,17 @@ export async function handleAddItemsToCollection(
       added.push(itemKey);
     }
 
+    let notificationStatus = "not-needed";
     if (added.length > 0) {
+      const notifierQueue = createNotifierQueue();
       const itemIDs = (await Promise.all(added.map(
         (key: string) => Zotero.Items.getByLibraryAndKeyAsync(libraryID, key),
       ))).map((item) => (item as Zotero.Item).id);
       await Zotero.DB.executeTransaction(async () => {
-        await collection.addItems(itemIDs);
+        await collection.addItems(itemIDs, notifierSaveOptions(notifierQueue));
       });
+      const notification = await commitNotifierQueue(notifierQueue, `add items to collection ${collectionKey}`);
+      notificationStatus = notification.status;
     }
 
     ztoolkit.log(
@@ -1373,6 +1403,7 @@ export async function handleAddItemsToCollection(
       headers: { "Content-Type": "application/json; charset=utf-8" },
       body: JSON.stringify({
         success: true,
+        notificationStatus,
         collectionKey,
         added,
         notFound,
@@ -1471,6 +1502,7 @@ export async function handleRemoveItemsFromCollection(
       headers: { "Content-Type": "application/json; charset=utf-8" },
       body: JSON.stringify({
         success: true,
+        notificationStatus: "completed",
         collectionKey,
         removed,
         notFound,

--- a/zotero-mcp-plugin/src/modules/deferredNotifierCommitter.ts
+++ b/zotero-mcp-plugin/src/modules/deferredNotifierCommitter.ts
@@ -1,0 +1,178 @@
+export interface DeferredNotifierCommitResult {
+  completed: boolean;
+  elapsedMs: number;
+  pending: number;
+  status: "completed" | "pending" | "failed";
+  error?: string;
+}
+
+type LogLevel = "warn" | "error";
+type Logger = (message: string, level?: LogLevel) => void;
+
+const NOTIFIER_FOREGROUND_WAIT_MS = 250;
+
+/**
+ * Commit Zotero notifier queues in order without letting a slow observer hold
+ * an MCP write response indefinitely. The commit itself is never cancelled.
+ */
+export class DeferredNotifierCommitter {
+  private tail: Promise<void> = Promise.resolve();
+  private pending = 0;
+
+  constructor(
+    private readonly maxForegroundWaitMs: number,
+    private readonly log: Logger,
+  ) {}
+
+  async enqueue(
+    label: string,
+    commit: () => Promise<unknown>,
+  ): Promise<DeferredNotifierCommitResult> {
+    const startedAt = Date.now();
+    this.pending++;
+    let commitError: unknown;
+
+    const scheduled = this.tail.then(async () => {
+      await commit();
+    });
+
+    const settled = scheduled.then(
+      () => undefined,
+      (error) => {
+        commitError = error;
+        try {
+          this.log(
+            `[StreamableMCP] Deferred notifier commit failed for ${label}: ${error}`,
+            "error",
+          );
+        } catch {
+          // Logging must not leave the serialized notifier chain rejected.
+        }
+      },
+    );
+
+    this.tail = settled.finally(() => {
+      this.pending--;
+    });
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const completed = await Promise.race([
+      settled.then(() => true),
+      new Promise<false>((resolve) => {
+        timer = setTimeout(() => resolve(false), this.maxForegroundWaitMs);
+      }),
+    ]);
+
+    if (timer) clearTimeout(timer);
+
+    const error = commitError === undefined ? undefined : String(commitError);
+
+    return {
+      completed,
+      elapsedMs: Date.now() - startedAt,
+      pending: this.pending,
+      status: completed ? (error ? "failed" : "completed") : "pending",
+      ...(error ? { error } : {}),
+    };
+  }
+
+  async flush(maxWaitMs: number): Promise<boolean> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const completed = await Promise.race([
+      this.tail.then(() => true),
+      new Promise<false>((resolve) => {
+        timer = setTimeout(() => resolve(false), maxWaitMs);
+      }),
+    ]);
+
+    if (timer) clearTimeout(timer);
+    return completed;
+  }
+
+  getPendingCount(): number {
+    return this.pending;
+  }
+}
+
+const notifierCommitter = new DeferredNotifierCommitter(
+  NOTIFIER_FOREGROUND_WAIT_MS,
+  (message, level) => ztoolkit.log(message, level),
+);
+
+let writeTail: Promise<void> = Promise.resolve();
+let pendingWrites = 0;
+
+export async function runSerializedWrite<T>(
+  operation: () => Promise<T>,
+): Promise<T> {
+  pendingWrites++;
+  let release!: () => void;
+  const previous = writeTail;
+  writeTail = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  await previous;
+  try {
+    return await operation();
+  } finally {
+    pendingWrites--;
+    release();
+  }
+}
+
+export async function flushWriteOperations(maxWaitMs = 5000): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const completed = await Promise.race([
+    writeTail.then(() => true),
+    new Promise<false>((resolve) => {
+      timer = setTimeout(() => resolve(false), maxWaitMs);
+    }),
+  ]);
+
+  if (timer) clearTimeout(timer);
+  if (!completed) {
+    ztoolkit.log(
+      `[StreamableMCP] Shutdown timed out with ${pendingWrites} write operation(s) still pending`,
+      "warn",
+    );
+  }
+  return completed;
+}
+
+export function createNotifierQueue(): any {
+  return new (Zotero.Notifier as any).Queue();
+}
+
+export function notifierSaveOptions(notifierQueue: any): any {
+  return { skipSelect: true, notifierQueue };
+}
+
+export async function commitNotifierQueue(
+  notifierQueue: any,
+  label: string,
+): Promise<DeferredNotifierCommitResult> {
+  const result = await notifierCommitter.enqueue(label, () =>
+    (Zotero.Notifier as any).commit(notifierQueue),
+  );
+
+  if (!result.completed) {
+    ztoolkit.log(
+      `[StreamableMCP] Database commit completed for ${label}; ${result.pending} notifier queue(s) still running after ${result.elapsedMs}ms`,
+      "warn",
+    );
+  }
+
+  return result;
+}
+
+export async function flushNotifierCommits(maxWaitMs = 2000): Promise<boolean> {
+  const completed = await notifierCommitter.flush(maxWaitMs);
+  if (!completed) {
+    ztoolkit.log(
+      `[StreamableMCP] Shutdown timed out with ${notifierCommitter.getPendingCount()} notifier queue(s) still pending`,
+      "warn",
+    );
+  }
+  return completed;
+}

--- a/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
+++ b/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
@@ -20,6 +20,12 @@ import { UnifiedContentExtractor } from './unifiedContentExtractor';
 import { SmartAnnotationExtractor } from './smartAnnotationExtractor';
 import { MCPSettingsService } from './mcpSettingsService';
 import { getSemanticSearchService, SemanticSearchService } from './semantic';
+import {
+  commitNotifierQueue,
+  createNotifierQueue,
+  notifierSaveOptions,
+  runSerializedWrite,
+} from './deferredNotifierCommitter';
 
 export interface MCPRequest {
   jsonrpc: '2.0';
@@ -1175,7 +1181,7 @@ export class StreamableMCPServer {
           if (!args?.name) {
             throw new Error('name is required');
           }
-          result = await this.callCreateCollection(args);
+          result = await runSerializedWrite(() => this.callCreateCollection(args));
           break;
         }
 
@@ -1187,7 +1193,7 @@ export class StreamableMCPServer {
           if (!args?.collectionKey) {
             throw new Error('collectionKey is required');
           }
-          result = await this.callUpdateCollection(args);
+          result = await runSerializedWrite(() => this.callUpdateCollection(args));
           break;
         }
 
@@ -1199,7 +1205,7 @@ export class StreamableMCPServer {
           if (!args?.collectionKey) {
             throw new Error('collectionKey is required');
           }
-          result = await this.callDeleteCollection(args);
+          result = await runSerializedWrite(() => this.callDeleteCollection(args));
           break;
         }
 
@@ -1215,7 +1221,7 @@ export class StreamableMCPServer {
           if (!addKeys || addKeys.length === 0) {
             throw new Error(`itemKeys array is required, e.g. ["ABCD1234"]. Received: ${JSON.stringify(args?.itemKeys)}`);
           }
-          result = await this.callAddItemsToCollection({ ...args, itemKeys: addKeys });
+          result = await runSerializedWrite(() => this.callAddItemsToCollection({ ...args, itemKeys: addKeys }));
           break;
         }
 
@@ -1231,7 +1237,7 @@ export class StreamableMCPServer {
           if (!removeKeys || removeKeys.length === 0) {
             throw new Error(`itemKeys array is required, e.g. ["ABCD1234"]. Received: ${JSON.stringify(args?.itemKeys)}`);
           }
-          result = await this.callRemoveItemsFromCollection({ ...args, itemKeys: removeKeys });
+          result = await runSerializedWrite(() => this.callRemoveItemsFromCollection({ ...args, itemKeys: removeKeys }));
           break;
         }
 
@@ -1285,7 +1291,7 @@ export class StreamableMCPServer {
           if (!args?.action || !args?.content) {
             throw new Error('action and content are required');
           }
-          result = await this.callWriteNote(args);
+          result = await runSerializedWrite(() => this.callWriteNote(args));
           break;
         }
 
@@ -1297,7 +1303,7 @@ export class StreamableMCPServer {
           if (!args?.action || !args?.itemKey || !args?.tags) {
             throw new Error('action, itemKey, and tags are required');
           }
-          result = await this.callWriteTag(args);
+          result = await runSerializedWrite(() => this.callWriteTag(args));
           break;
         }
 
@@ -1312,7 +1318,7 @@ export class StreamableMCPServer {
           if (!args?.fields && !args?.creators) {
             throw new Error('At least one of fields or creators is required');
           }
-          result = await this.callWriteMetadata(args);
+          result = await runSerializedWrite(() => this.callWriteMetadata(args));
           break;
         }
 
@@ -1324,7 +1330,7 @@ export class StreamableMCPServer {
           if (!args?.action) {
             throw new Error('action is required');
           }
-          result = await this.callWriteItem(args);
+          result = await runSerializedWrite(() => this.callWriteItem(args));
           break;
         }
 
@@ -2039,7 +2045,9 @@ export class StreamableMCPServer {
             }
           }
 
-          await note.saveTx();
+          const notifierQueue = createNotifierQueue();
+          await note.saveTx(notifierSaveOptions(notifierQueue));
+          const notification = await commitNotifierQueue(notifierQueue, `create note ${note.key}`);
 
           ztoolkit.log(`[StreamableMCP] Created note ${note.key}${parentKey ? ' attached to ' + parentKey : ' (standalone)'}`);
 
@@ -2057,6 +2065,7 @@ export class StreamableMCPServer {
             },
             metadata: {
               extractedAt: new Date().toISOString(),
+              notificationStatus: notification.status,
               message: `Note created successfully (key: ${note.key})`
             }
           };
@@ -2085,7 +2094,9 @@ export class StreamableMCPServer {
             }
           }
 
-          await existingNote.saveTx();
+          const notifierQueue = createNotifierQueue();
+          await existingNote.saveTx(notifierSaveOptions(notifierQueue));
+          const notification = await commitNotifierQueue(notifierQueue, `update note ${noteKey}`);
 
           ztoolkit.log(`[StreamableMCP] Updated note ${noteKey}`);
 
@@ -2101,6 +2112,7 @@ export class StreamableMCPServer {
             },
             metadata: {
               extractedAt: new Date().toISOString(),
+              notificationStatus: notification.status,
               message: `Note ${noteKey} updated successfully`
             }
           };
@@ -2131,7 +2143,9 @@ export class StreamableMCPServer {
             }
           }
 
-          await existingNote.saveTx();
+          const notifierQueue = createNotifierQueue();
+          await existingNote.saveTx(notifierSaveOptions(notifierQueue));
+          const notification = await commitNotifierQueue(notifierQueue, `append note ${noteKey}`);
 
           ztoolkit.log(`[StreamableMCP] Appended to note ${noteKey}`);
 
@@ -2148,6 +2162,7 @@ export class StreamableMCPServer {
             },
             metadata: {
               extractedAt: new Date().toISOString(),
+              notificationStatus: notification.status,
               message: `Content appended to note ${noteKey} successfully`
             }
           };
@@ -2212,7 +2227,9 @@ export class StreamableMCPServer {
           throw new Error(`Unknown action: ${action}. Use add, remove, or set.`);
       }
 
-      await item.saveTx();
+      const notifierQueue = createNotifierQueue();
+      await item.saveTx(notifierSaveOptions(notifierQueue));
+      const notification = await commitNotifierQueue(notifierQueue, `write tags on ${itemKey}`);
 
       const afterTags = item.getTags().map((t: any) => t.tag);
 
@@ -2229,6 +2246,7 @@ export class StreamableMCPServer {
         },
         metadata: {
           extractedAt: new Date().toISOString(),
+          notificationStatus: notification.status,
           message: `Tags ${action === 'add' ? 'added to' : action === 'remove' ? 'removed from' : 'set on'} item ${itemKey}`
         }
       };
@@ -2302,7 +2320,9 @@ export class StreamableMCPServer {
         afterCreators = creators;
       }
 
-      await item.saveTx();
+      const notifierQueue = createNotifierQueue();
+      await item.saveTx(notifierSaveOptions(notifierQueue));
+      const notification = await commitNotifierQueue(notifierQueue, `update metadata on ${itemKey}`);
 
       ztoolkit.log(`[StreamableMCP] Updated metadata on ${itemKey}: fields=[${Object.keys(updatedFields).join(', ')}], creators=${creatorsUpdated}`);
 
@@ -2316,6 +2336,7 @@ export class StreamableMCPServer {
         },
         metadata: {
           extractedAt: new Date().toISOString(),
+          notificationStatus: notification.status,
           message: `Metadata updated on item ${itemKey}`
         }
       };
@@ -2377,31 +2398,42 @@ export class StreamableMCPServer {
             }
           }
 
-          await item.saveTx();
-
-          ztoolkit.log(`[StreamableMCP] Created item ${item.key} (type: ${itemType})`);
-
-          // Re-parent attachments if provided
+          const notifierQueue = createNotifierQueue();
           const reparentedAttachments: string[] = [];
-          if (attachmentKeys && Array.isArray(attachmentKeys)) {
-            for (const attKey of attachmentKeys) {
-              const attachment = await Zotero.Items.getByLibraryAndKeyAsync(
-                libraryID, attKey
-              );
-              if (!attachment) {
-                ztoolkit.log(`[StreamableMCP] Attachment not found in library ${libraryID}: ${attKey}`, 'warn');
-                continue;
+          let writeFailed = false;
+          let writeError: unknown;
+
+          try {
+            await item.saveTx(notifierSaveOptions(notifierQueue));
+            ztoolkit.log(`[StreamableMCP] Created item ${item.key} (type: ${itemType})`);
+
+            // Re-parent attachments if provided
+            if (attachmentKeys && Array.isArray(attachmentKeys)) {
+              for (const attKey of attachmentKeys) {
+                const attachment = await Zotero.Items.getByLibraryAndKeyAsync(
+                  libraryID, attKey
+                );
+                if (!attachment) {
+                  ztoolkit.log(`[StreamableMCP] Attachment not found in library ${libraryID}: ${attKey}`, 'warn');
+                  continue;
+                }
+                if (!attachment.isAttachment()) {
+                  ztoolkit.log(`[StreamableMCP] Item ${attKey} is not an attachment (type: ${attachment.itemType}), skipping`, 'warn');
+                  continue;
+                }
+                attachment.parentKey = item.key;
+                await attachment.saveTx(notifierSaveOptions(notifierQueue));
+                reparentedAttachments.push(attKey);
+                ztoolkit.log(`[StreamableMCP] Re-parented attachment ${attKey} under ${item.key}`);
               }
-              if (!attachment.isAttachment()) {
-                ztoolkit.log(`[StreamableMCP] Item ${attKey} is not an attachment (type: ${attachment.itemType}), skipping`, 'warn');
-                continue;
-              }
-              attachment.parentKey = item.key;
-              await attachment.saveTx();
-              reparentedAttachments.push(attKey);
-              ztoolkit.log(`[StreamableMCP] Re-parented attachment ${attKey} under ${item.key}`);
             }
+          } catch (error) {
+            writeFailed = true;
+            writeError = error;
           }
+
+          const notification = await commitNotifierQueue(notifierQueue, `create item ${item.key}`);
+          if (writeFailed) throw writeError;
 
           return {
             action: 'create',
@@ -2417,6 +2449,7 @@ export class StreamableMCPServer {
             },
             metadata: {
               extractedAt: new Date().toISOString(),
+              notificationStatus: notification.status,
               message: `Item created (key: ${item.key}, type: ${itemType})${reparentedAttachments.length > 0 ? `, ${reparentedAttachments.length} attachment(s) attached` : ''}`
             }
           };
@@ -2442,6 +2475,7 @@ export class StreamableMCPServer {
           }
 
           const results: Array<{ key: string; success: boolean; error?: string }> = [];
+          const notifierQueue = createNotifierQueue();
           for (const attKey of attachmentKeys) {
             try {
               const attachment = await Zotero.Items.getByLibraryAndKeyAsync(
@@ -2456,7 +2490,7 @@ export class StreamableMCPServer {
                 continue;
               }
               attachment.parentKey = parentKey;
-              await attachment.saveTx();
+              await attachment.saveTx(notifierSaveOptions(notifierQueue));
               results.push({ key: attKey, success: true });
               ztoolkit.log(`[StreamableMCP] Re-parented ${attKey} under ${parentKey}`);
             } catch (attError) {
@@ -2464,6 +2498,7 @@ export class StreamableMCPServer {
             }
           }
 
+          const notification = await commitNotifierQueue(notifierQueue, `reparent items under ${parentKey}`);
           const successCount = results.filter(r => r.success).length;
 
           return {
@@ -2477,6 +2512,7 @@ export class StreamableMCPServer {
             },
             metadata: {
               extractedAt: new Date().toISOString(),
+              notificationStatus: notification.status,
               message: `Re-parented ${successCount}/${attachmentKeys.length} item(s) under ${parentKey}`
             }
           };
@@ -2506,11 +2542,14 @@ export class StreamableMCPServer {
           }
 
           // Import file as attachment
+          const notifierQueue = createNotifierQueue();
           const attachment = await Zotero.Attachments.importFromFile({
             file: filePath,
             parentItemID: parentItem.id,
-            title: title || filePath.split(/[\\/]/).pop() || 'Imported Attachment'
+            title: title || filePath.split(/[\\/]/).pop() || 'Imported Attachment',
+            saveOptions: notifierSaveOptions(notifierQueue)
           });
+          const notification = await commitNotifierQueue(notifierQueue, `import attachment ${attachment.key}`);
 
           ztoolkit.log(`[StreamableMCP] Imported file as attachment ${attachment.key} under ${importParentKey}`);
 
@@ -2525,6 +2564,7 @@ export class StreamableMCPServer {
             },
             metadata: {
               extractedAt: new Date().toISOString(),
+              notificationStatus: notification.status,
               message: `File imported as attachment (key: ${attachment.key}) under parent ${importParentKey}`
             }
           };

--- a/zotero-mcp-plugin/test/writeOperations.test.ts
+++ b/zotero-mcp-plugin/test/writeOperations.test.ts
@@ -1,0 +1,245 @@
+import { StreamableMCPServer } from "../src/modules/streamableMCPServer";
+import {
+  DeferredNotifierCommitter,
+  flushWriteOperations,
+  runSerializedWrite,
+} from "../src/modules/deferredNotifierCommitter";
+
+declare const expect: Chai.ExpectStatic;
+
+const WRITE_ENABLED_PREF = "extensions.zotero.zotero-mcp-plugin.write.enabled";
+
+describe("MCP write operations", function () {
+  it("returns after the database commit when a notifier observer is slow", async function () {
+    this.timeout(5000);
+
+    (globalThis as any).ztoolkit = { log: () => undefined };
+    const server = new StreamableMCPServer();
+    const title = `MCP slow-notifier regression ${Date.now()}`;
+    let itemKey: string | undefined;
+    let observerStarted = false;
+    let observerCompleted = false;
+    let notifiedIDs: Array<string | number> = [];
+
+    Zotero.Prefs.set(WRITE_ENABLED_PREF, true, true);
+
+    const observerID = Zotero.Notifier.registerObserver(
+      {
+        notify: async (
+          _event: string,
+          _type: string,
+          ids: Array<string | number>,
+        ) => {
+          observerStarted = true;
+          notifiedIDs = ids;
+          await Zotero.Promise.delay(1000);
+          observerCompleted = true;
+        },
+      },
+      ["item"],
+      `mcp-slow-notifier-test-${Date.now()}`,
+      1,
+    );
+
+    try {
+      const startedAt = Date.now();
+      const response = await server.handleMCPRequest(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "write_item",
+            arguments: {
+              action: "create",
+              itemType: "journalArticle",
+              fields: { title },
+            },
+          },
+        }),
+      );
+      const elapsedMs = Date.now() - startedAt;
+
+      const envelope = JSON.parse(response.body);
+      const result = JSON.parse(envelope.result.content[0].text);
+      itemKey = result.data.itemKey;
+      const item = await Zotero.Items.getByLibraryAndKeyAsync(
+        Zotero.Libraries.userLibraryID,
+        itemKey,
+      );
+
+      if (!result.success) {
+        throw {
+          message: `write failed: ${JSON.stringify(result)}`,
+          actual: result,
+          expected: { success: true },
+        };
+      }
+      if (!observerStarted) {
+        throw {
+          message: "target notifier observer did not run",
+          actual: observerStarted,
+          expected: true,
+        };
+      }
+      expect(item?.getField("title")).to.equal(title);
+      expect(notifiedIDs).to.include(item!.id);
+      expect(result.metadata.notificationStatus).to.equal("pending");
+      if (elapsedMs >= 600) {
+        throw {
+          message: `write response took ${elapsedMs} ms while waiting for a slow observer`,
+          actual: elapsedMs,
+          expected: "< 600",
+        };
+      }
+
+      await Zotero.Promise.delay(1100);
+      expect(observerCompleted).to.equal(true);
+    } catch (error) {
+      const diagnostic =
+        error && typeof error === "object"
+          ? {
+              ...(error as Record<string, unknown>),
+              message:
+                (error as { message?: string }).message ||
+                JSON.stringify(error),
+            }
+          : { message: String(error) };
+      throw diagnostic;
+    } finally {
+      Zotero.Notifier.unregisterObserver(observerID);
+      if (itemKey) {
+        const item = await Zotero.Items.getByLibraryAndKeyAsync(
+          Zotero.Libraries.userLibraryID,
+          itemKey,
+        );
+        if (item) {
+          await item.eraseTx({ skipNotifier: true });
+        }
+      }
+    }
+  });
+
+  it("does not hold collection creation on a slow notifier observer", async function () {
+    this.timeout(5000);
+
+    (globalThis as any).ztoolkit = { log: () => undefined };
+    const server = new StreamableMCPServer();
+    let collectionKey: string | undefined;
+    let observerStarted = false;
+    let observerCompleted = false;
+
+    Zotero.Prefs.set(WRITE_ENABLED_PREF, true, true);
+
+    const observerID = Zotero.Notifier.registerObserver(
+      {
+        notify: async () => {
+          observerStarted = true;
+          await Zotero.Promise.delay(1000);
+          observerCompleted = true;
+        },
+      },
+      ["collection"],
+      `mcp-slow-collection-notifier-test-${Date.now()}`,
+      1,
+    );
+
+    try {
+      const startedAt = Date.now();
+      const response = await server.handleMCPRequest(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: {
+            name: "create_collection",
+            arguments: { name: `MCP notifier test ${Date.now()}` },
+          },
+        }),
+      );
+      const elapsedMs = Date.now() - startedAt;
+
+      const envelope = JSON.parse(response.body);
+      const result = JSON.parse(envelope.result.content[0].text);
+      collectionKey = result.key;
+      const collection = await Zotero.Collections.getByLibraryAndKeyAsync(
+        Zotero.Libraries.userLibraryID,
+        collectionKey,
+      );
+
+      expect(collection?.name).to.match(/^MCP notifier test /);
+      expect(result.notificationStatus).to.equal("pending");
+      expect(observerStarted).to.equal(true);
+      expect(elapsedMs).to.be.lessThan(600);
+
+      await Zotero.Promise.delay(1100);
+      expect(observerCompleted).to.equal(true);
+    } finally {
+      Zotero.Notifier.unregisterObserver(observerID);
+      if (collectionKey) {
+        const collection = await Zotero.Collections.getByLibraryAndKeyAsync(
+          Zotero.Libraries.userLibraryID,
+          collectionKey,
+        );
+        if (collection) {
+          await collection.eraseTx({ skipNotifier: true });
+        }
+      }
+    }
+  });
+
+  it("reports notifier failures without rejecting the serialized chain", async function () {
+    const logs: string[] = [];
+    const committer = new DeferredNotifierCommitter(50, (message) => {
+      logs.push(message);
+    });
+
+    const result = await committer.enqueue("rejected test queue", async () => {
+      throw new Error("observer failure");
+    });
+
+    expect(result.status).to.equal("failed");
+    expect(result.error).to.contain("observer failure");
+    expect(logs).to.have.length(1);
+    expect(await committer.flush(50)).to.equal(true);
+  });
+
+  it("serializes overlapping Zotero write handlers", async function () {
+    const events: string[] = [];
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = runSerializedWrite(async () => {
+      events.push("first-start");
+      await firstGate;
+      events.push("first-end");
+    });
+    const second = runSerializedWrite(async () => {
+      events.push("second-start");
+      events.push("second-end");
+    });
+
+    await Zotero.Promise.delay(20);
+    expect(events).to.deep.equal(["first-start"]);
+
+    const drain = flushWriteOperations(200);
+    let drained = false;
+    drain.then(() => {
+      drained = true;
+    });
+    await Zotero.Promise.delay(20);
+    expect(drained).to.equal(false);
+
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(await drain).to.equal(true);
+    expect(events).to.deep.equal([
+      "first-start",
+      "first-end",
+      "second-start",
+      "second-end",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- await every Zotero database transaction before returning, but move supported write notifications to explicit `Zotero.Notifier.Queue` instances
- serialize MCP mutations and notifier commits, then return after a 250 ms notification grace period with an explicit `notificationStatus`
- reuse one notifier queue for compound item/reparent operations and drain active writes plus notifier queues during shutdown
- add real Zotero integration regressions for slow observers, committed-state readback, notification failure, and write serialization

## Problem

`saveTx()` does not necessarily return when SQLite commits. Zotero runs commit callbacks afterwards, and `Notifier.commit()` awaits each observer in sequence. A slow observer can therefore keep an MCP write waiting after the database change is already durable, which encourages client retries and duplicate create/import operations.

Relevant Zotero implementation:

- [`DataObject.save()` / `saveTx()`](https://github.com/zotero/zotero/blob/753dbf557ad4fbd958594253c9ff28e585d7837c/chrome/content/zotero/xpcom/data/dataObject.js#L991-L1134)
- [`Notifier.trigger()` / `Notifier.commit()`](https://github.com/zotero/zotero/blob/753dbf557ad4fbd958594253c9ff28e585d7837c/chrome/content/zotero/xpcom/notifier.js#L113-L179)

The regression test injects a one-second item observer. Before this change, a create response took about 1118 ms. With this change, item and collection creates return in under 600 ms, the new object is immediately readable, and the delayed observer still completes.

## Safety boundary

- This does **not** race or cancel `saveTx()`. The database transaction must finish first.
- Notifications are never skipped or cancelled. Deferred MCP queues continue in MCP submission order and are drained on shutdown with a bounded wait; Zotero-native notification sources can still interleave.
- Responses distinguish `completed`, `pending`, and `failed` notification state.
- `delete_collection(deleteItems=true)` and `remove_items_from_collection` intentionally keep Zotero's native synchronous notification path because those Zotero APIs do not propagate a custom queue through their child-item operations.
- The 250 ms bound applies only to post-commit notifier work. File copying and full-text indexing inside `importFromFile()` remain synchronous.

## Validation

- `npm run build`
- `ZOTERO_PLUGIN_ZOTERO_BIN_PATH=/Applications/Zotero.app/Contents/MacOS/zotero npm test -- --no-watch --abort-on-fail` — 4 passed
- `npx prettier --check src/modules/deferredNotifierCommitter.ts test/writeOperations.test.ts`
- `npx eslint src/modules/deferredNotifierCommitter.ts test/writeOperations.test.ts`
- `git diff --check`
- isolated test-profile cleanup verified: 0 test items and 0 test collections remain

The repository-wide `npm run lint:check` is already non-zero on `main` because 30 existing files fail the Prettier check. The touched existing files retain only the same seven ESLint findings reproducible from `main`; the new helper and tests pass targeted ESLint and Prettier checks.
