### PR TITLE
feat(write): add safe trash_item tool

### DIFF
--- a/zotero-mcp-plugin/src/modules/apiHandlers.ts
+++ b/zotero-mcp-plugin/src/modules/apiHandlers.ts
@@ -1530,3 +1530,130 @@ export async function handleRemoveItemsFromCollection(
     };
   }
 }
+
+/**
+ * Moves items to Zotero Trash. Permanent deletion is intentionally unsupported.
+ */
+export async function handleTrashItems(
+  _params: Record<string, string>,
+  body: { itemKeys?: string[]; libraryID?: number },
+): Promise<HttpResponse> {
+  try {
+    if (Object.prototype.hasOwnProperty.call(body, "permanent")) {
+      return {
+        status: 400,
+        statusText: "Bad Request",
+        headers: { "Content-Type": "application/json; charset=utf-8" },
+        body: JSON.stringify({
+          error:
+            "The permanent option is not supported. Items can only be moved to Zotero Trash.",
+        }),
+      };
+    }
+
+    const keys = Array.isArray(body.itemKeys)
+      ? [
+          ...new Set(
+            body.itemKeys
+              .map((key) => String(key).trim())
+              .filter(Boolean),
+          ),
+        ]
+      : [];
+
+    if (keys.length === 0) {
+      return {
+        status: 400,
+        statusText: "Bad Request",
+        headers: { "Content-Type": "application/json; charset=utf-8" },
+        body: JSON.stringify({ error: "itemKeys array is required" }),
+      };
+    }
+
+    const libraryID = body.libraryID ?? Zotero.Libraries.userLibraryID;
+    const items: Zotero.Item[] = [];
+    const notFound: string[] = [];
+
+    for (const key of keys) {
+      const item = await Zotero.Items.getByLibraryAndKeyAsync(
+        libraryID,
+        key,
+      );
+      if (item) {
+        items.push(item);
+      } else {
+        notFound.push(key);
+      }
+    }
+
+    if (items.length === 0) {
+      return {
+        status: 404,
+        statusText: "Not Found",
+        headers: { "Content-Type": "application/json; charset=utf-8" },
+        body: JSON.stringify({
+          error: `No items found in library ${libraryID}`,
+          notFound,
+        }),
+      };
+    }
+
+    const trashed: Array<{
+      key: string;
+      title: string;
+      itemType: string;
+    }> = [];
+    const notifierQueue = createNotifierQueue();
+    let writeFailed = false;
+    let writeError: unknown;
+
+    try {
+      for (const item of items) {
+        const summary = {
+          key: item.key,
+          title: item.getDisplayTitle ? item.getDisplayTitle() : "",
+          itemType: Zotero.ItemTypes.getName(item.itemTypeID),
+        };
+        item.deleted = true;
+        await item.saveTx(notifierSaveOptions(notifierQueue));
+        trashed.push(summary);
+      }
+    } catch (error) {
+      writeFailed = true;
+      writeError = error;
+    }
+
+    // A batch can fail after earlier saveTx calls have committed. Hand their
+    // queued notifications to the deferred committer before surfacing the
+    // error, matching the other write handlers.
+    const notification = await commitNotifierQueue(
+      notifierQueue,
+      `trash ${trashed.length} item(s)`,
+    );
+    if (writeFailed) throw writeError;
+
+    ztoolkit.log(`[ApiHandlers] Trashed ${trashed.length} item(s)`);
+
+    return {
+      status: 200,
+      statusText: "OK",
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+      body: JSON.stringify({
+        success: true,
+        notificationStatus: notification.status,
+        trashedCount: trashed.length,
+        trashed,
+        notFound,
+      }),
+    };
+  } catch (e) {
+    const error = e instanceof Error ? e : new Error(String(e));
+    Zotero.logError(error);
+    return {
+      status: 500,
+      statusText: "Internal Server Error",
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+      body: JSON.stringify({ error: error.message }),
+    };
+  }
+}

--- a/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
+++ b/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
@@ -13,6 +13,7 @@ import {
   handleCreateCollection,
   handleUpdateCollection,
   handleDeleteCollection,
+  handleTrashItems,
   handleAddItemsToCollection,
   handleRemoveItemsFromCollection,
 } from './apiHandlers';
@@ -721,6 +722,26 @@ export class StreamableMCPServer {
         },
       },
       {
+        name: 'trash_item',
+        description: 'Move one or more items to Zotero Trash. Items remain recoverable until the user empties Trash; permanent deletion is not supported.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
+            itemKeys: {
+              type: 'array',
+              items: { type: 'string' },
+              minItems: 1,
+              description: 'Item keys to move to Trash, e.g. ["ABCD1234"]'
+            },
+          },
+          required: ['itemKeys'],
+        },
+      },
+      {
         name: 'add_items_to_collection',
         description: 'Add one or more items to a collection by their item keys.',
         inputSchema: {
@@ -1145,6 +1166,7 @@ export class StreamableMCPServer {
     const writeEnabled = Zotero.Prefs.get('extensions.zotero.zotero-mcp-plugin.write.enabled', true);
     const writeToolNames = new Set([
       'write_note', 'write_tag', 'write_metadata', 'write_item', 'add_by_identifier',
+      'trash_item',
     ]);
     const finalTools = writeEnabled === true
       ? filteredTools
@@ -1254,6 +1276,24 @@ export class StreamableMCPServer {
             throw new Error('collectionKey is required');
           }
           result = await runSerializedWrite(() => this.callUpdateCollection(args));
+          break;
+        }
+
+        case 'trash_item': {
+          const writeEnabledTI = Zotero.Prefs.get('extensions.zotero.zotero-mcp-plugin.write.enabled', true);
+          if (writeEnabledTI !== true) {
+            throw new Error('Write operations are currently disabled. Please go to Zotero → Tools → Add-ons → Zotero MCP Plugin → Preferences, and enable "Write Operations" to use this feature.');
+          }
+          if (args && Object.prototype.hasOwnProperty.call(args, 'permanent')) {
+            throw new Error('The permanent option is not supported. Items can only be moved to Zotero Trash.');
+          }
+          const itemKeys = this.coerceStringArray(args?.itemKeys);
+          if (!itemKeys || itemKeys.length === 0) {
+            throw new Error(`itemKeys array is required, e.g. ["ABCD1234"]. Received: ${JSON.stringify(args?.itemKeys)}`);
+          }
+          result = await runSerializedWrite(() =>
+            this.callTrashItems({ ...args, itemKeys }),
+          );
           break;
         }
 
@@ -1701,6 +1741,11 @@ export class StreamableMCPServer {
   private async callUpdateCollection(args: any): Promise<any> {
     const { collectionKey, ...body } = args;
     const response = await handleUpdateCollection({ 1: collectionKey }, body);
+    return response.body ? JSON.parse(response.body) : response;
+  }
+
+  private async callTrashItems(args: any): Promise<any> {
+    const response = await handleTrashItems({}, args);
     return response.body ? JSON.parse(response.body) : response;
   }
 
@@ -3287,7 +3332,8 @@ export class StreamableMCPServer {
         'write_tag',
         'write_metadata',
         'write_item',
-        'add_by_identifier'
+        'add_by_identifier',
+        'trash_item'
       ],
       transport: {
         type: "streamable-http",

--- a/zotero-mcp-plugin/test/writeOperations.test.ts
+++ b/zotero-mcp-plugin/test/writeOperations.test.ts
@@ -1,3 +1,4 @@
+import { handleTrashItems } from "../src/modules/apiHandlers";
 import { StreamableMCPServer } from "../src/modules/streamableMCPServer";
 import {
   DeferredNotifierCommitter,
@@ -241,5 +242,178 @@ describe("MCP write operations", function () {
       "second-start",
       "second-end",
     ]);
+  });
+
+  it("moves items to Trash safely and rejects permanent deletion", async function () {
+    this.timeout(20000);
+
+    (globalThis as any).ztoolkit = { log: () => undefined };
+    const server = new StreamableMCPServer();
+    const createdKeys: string[] = [];
+    let requestID = 100;
+
+    Zotero.Prefs.set(WRITE_ENABLED_PREF, true, true);
+
+    const request = async (method: string, params?: unknown) => {
+      const response = await server.handleMCPRequest(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: requestID++,
+          method,
+          ...(params === undefined ? {} : { params }),
+        }),
+      );
+      return JSON.parse(response.body);
+    };
+
+    const callTool = (name: string, args: unknown) =>
+      request("tools/call", { name, arguments: args });
+
+    const parseToolResult = (envelope: any) => {
+      expect(envelope).not.to.have.property("error");
+      return JSON.parse(envelope.result.content[0].text);
+    };
+
+    const makeItem = async (title: string) => {
+      const envelope = await callTool("write_item", {
+        action: "create",
+        itemType: "journalArticle",
+        fields: { title },
+      });
+      const created = parseToolResult(envelope);
+      const key = created.data.itemKey as string;
+      createdKeys.push(key);
+      return key;
+    };
+
+    try {
+      const toolsEnvelope = await request("tools/list", {});
+      const tools = toolsEnvelope.result.tools as Array<{
+        name: string;
+        inputSchema: {
+          properties: Record<string, any>;
+        };
+      }>;
+      const toolNames = tools.map((tool) => tool.name);
+      const trashTool = tools.find((tool) => tool.name === "trash_item");
+
+      expect(toolNames).to.include("trash_item");
+      expect(toolNames).not.to.include("delete_item");
+      expect(trashTool).not.to.equal(undefined);
+      expect(trashTool!.inputSchema.properties).not.to.have.property(
+        "permanent",
+      );
+      expect(trashTool!.inputSchema.properties.itemKeys.minItems).to.equal(1);
+      expect(server.getStatus().availableTools).to.include("trash_item");
+
+      const firstTitle = `MCP trash_item first ${Date.now()}`;
+      const secondTitle = `MCP trash_item second ${Date.now()}`;
+      const firstKey = await makeItem(firstTitle);
+      const secondKey = await makeItem(secondTitle);
+
+      const trashed = parseToolResult(
+        await callTool("trash_item", {
+          itemKeys: JSON.stringify([
+            ` ${firstKey} `,
+            firstKey,
+            secondKey,
+            "ZZZZNOPE",
+          ]),
+        }),
+      );
+
+      expect(trashed.success).to.equal(true);
+      expect(trashed.trashedCount).to.equal(2);
+      expect(trashed.trashed.map((item: any) => item.key)).to.deep.equal([
+        firstKey,
+        secondKey,
+      ]);
+      expect(trashed.trashed.map((item: any) => item.title)).to.deep.equal([
+        firstTitle,
+        secondTitle,
+      ]);
+      expect(trashed.trashed.map((item: any) => item.itemType)).to.deep.equal([
+        "journalArticle",
+        "journalArticle",
+      ]);
+      expect(trashed.notFound).to.deep.equal(["ZZZZNOPE"]);
+      expect(["completed", "pending"]).to.include(trashed.notificationStatus);
+      expect(trashed).not.to.have.property("permanent");
+      expect(trashed).not.to.have.property("deleted");
+
+      for (const key of [firstKey, secondKey]) {
+        const item = await Zotero.Items.getByLibraryAndKeyAsync(
+          Zotero.Libraries.userLibraryID,
+          key,
+        );
+        expect(
+          !!item,
+          `trashed item ${key} should remain retrievable`,
+        ).to.equal(true);
+        expect(item!.deleted).to.equal(true);
+      }
+
+      const missing = parseToolResult(
+        await callTool("trash_item", {
+          itemKeys: ["YYYYNOPE"],
+        }),
+      );
+      expect(missing.notFound).to.deep.equal(["YYYYNOPE"]);
+      expect(missing.error).to.contain("No items found");
+
+      const protectedKey = await makeItem(
+        `MCP trash_item protected ${Date.now()}`,
+      );
+
+      Zotero.Prefs.set(WRITE_ENABLED_PREF, false, true);
+      const hiddenTools = await request("tools/list", {});
+      expect(
+        hiddenTools.result.tools.map((tool: any) => tool.name),
+      ).not.to.include("trash_item");
+
+      const disabled = await callTool("trash_item", {
+        itemKeys: [protectedKey],
+      });
+      expect(disabled.error.message).to.contain(
+        "Write operations are currently disabled",
+      );
+
+      Zotero.Prefs.set(WRITE_ENABLED_PREF, true, true);
+      const refused = await callTool("trash_item", {
+        itemKeys: [protectedKey],
+        permanent: true,
+      });
+      expect(refused.error.code).to.equal(-32603);
+      expect(refused.error.message).to.contain(
+        "permanent option is not supported",
+      );
+
+      const directRefusal = await handleTrashItems({}, {
+        itemKeys: [protectedKey],
+        permanent: true,
+      } as any);
+      expect(directRefusal.status).to.equal(400);
+      expect(JSON.parse(directRefusal.body).error).to.contain(
+        "permanent option is not supported",
+      );
+
+      const protectedItem = await Zotero.Items.getByLibraryAndKeyAsync(
+        Zotero.Libraries.userLibraryID,
+        protectedKey,
+      );
+      expect(!!protectedItem).to.equal(true);
+      expect(protectedItem!.deleted).to.equal(false);
+    } finally {
+      Zotero.Prefs.set(WRITE_ENABLED_PREF, true, true);
+      for (const key of createdKeys) {
+        const item = await Zotero.Items.getByLibraryAndKeyAsync(
+          Zotero.Libraries.userLibraryID,
+          key,
+        );
+        if (item) {
+          await item.eraseTx({ skipNotifier: true });
+        }
+      }
+    }
   });
 });


### PR DESCRIPTION
## Problem

The server can create and import Zotero items, but there is currently no item-level operation for cleaning up mistaken, duplicate, or test entries without falling back to the Zotero UI.

This PR implements the recoverable, trash-only item operation requested in #98.

## What this adds

A new `trash_item` write tool for moving one or more items to Zotero Trash:

```jsonc
{
  "name": "trash_item",
  "arguments": {
    "itemKeys": ["ABCD1234", "EFGH5678"],
    "libraryID": 1 // optional; defaults to the user library
  }
}
```

A successful result reports:

* `trashedCount`
* the trashed items' keys, titles, and item types
* unresolved keys in `notFound`
* deferred notifier status

## Design and safety

* **Trash only.** Items are moved to Zotero Trash by setting their recoverable `deleted` state. There is no permanent erase path.
* **No `permanent` option.** `permanent` is absent from the tool schema and is explicitly rejected at both the MCP dispatch and underlying handler boundaries, so an older or mistaken caller cannot assume irreversible deletion occurred.
* **Existing write safeguards apply.** `trash_item` is hidden from `tools/list` when write operations are disabled, performs its own runtime preference check, and runs through the serialized write queue.
* **Batch input matches the existing write tools.** `itemKeys` accepts multiple keys, supports the existing string-array coercion behavior, trims whitespace, and deduplicates keys while preserving first-seen order.
* **Partial success is explicit.** Valid items are moved to Trash while unresolved keys are returned in `notFound`.
* **Responses preserve useful context.** Each successfully trashed item reports its key, display title, and item type.
* **Notifier handling follows the existing deferred-write pattern.** Item saves share a notifier queue. If a later `saveTx` fails after earlier writes have already committed, their queued notifications are still submitted to the deferred committer before the write error is surfaced.
* **Server status is kept current.** `trash_item` is included in `availableTools`.

## Tests

The Zotero integration test covers:

* `trash_item` appearing in `tools/list`
* the old `delete_item` name not being exposed
* absence of `permanent` from the schema
* `itemKeys.minItems = 1`
* `trash_item` appearing in `availableTools`
* write-disabled tool filtering
* runtime write-gate enforcement
* JSON-string array coercion
* key trimming and deduplication
* mixed valid and missing keys
* all-missing-key requests
* items remaining retrievable with `deleted === true`
* explicit rejection of `permanent` at the MCP boundary
* explicit rejection of `permanent` at the handler boundary
* rejected items remaining untouched
* cleanup of all test-created items

## Verification

Final commit:

```text
7fca2a13bfd693fde31c25bd7a4c11f7a2f7cd05
```

Rebuilt directly on the current upstream `main` and kept as a single feature commit.

```text
npm run build
PASS
(zotero-plugin build + tsc --noEmit)

npm test -- --abort-on-fail --exit-on-finish
PASS — 20 passed

npx prettier --check test/writeOperations.test.ts
PASS

git diff --check
PASS
```

Verification run:

https://github.com/JulianZJN/zotero-mcp/actions/runs/33758947673

Closes #98
