### PR TITLE
feat(citation): add bibliography export and CSL citation tools

### DIFF
--- a/zotero-mcp-plugin/src/modules/citationExportService.ts
+++ b/zotero-mcp-plugin/src/modules/citationExportService.ts
@@ -1,0 +1,399 @@
+/**
+ * Citation & bibliography export service.
+ *
+ * - BibTeX/BibLaTeX/CSL exports are provided by Better BibTeX (BBT) JSON-RPC.
+ * - Formatted references and in-text citations use Zotero's native Quick Copy API.
+ */
+
+declare let ztoolkit: ZToolkit;
+
+const BBT_TRANSLATORS: Record<string, string> = {
+  biblatex: "Better BibLaTeX",
+  bibtex: "Better BibTeX",
+  csljson: "Better CSL JSON",
+  cslyaml: "Better CSL YAML",
+};
+
+const BBT_DEFAULT_PORT = 23119;
+const APA_STYLE_ID = "http://www.zotero.org/styles/apa";
+
+type CitationMode = "bibliography" | "citation";
+type CitationContentType = "html" | "text";
+
+interface StyleInfo {
+  id?: string;
+  title?: string;
+  isDefault: boolean;
+  hasBibliography?: boolean;
+}
+
+export class CitationExportService {
+  private get bbtRpcUrl(): string {
+    return `http://localhost:${BBT_DEFAULT_PORT}/better-bibtex/json-rpc`;
+  }
+
+  private async bbtRpc(method: string, params: any[] = []): Promise<any> {
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      method,
+      params,
+      id: `zotero-mcp-${Date.now()}`,
+    });
+
+    let response: any;
+    try {
+      response = await Zotero.HTTP.request("POST", this.bbtRpcUrl, {
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+          "Zotero-Allowed-Request": "1",
+        },
+        body,
+        timeout: 30000,
+        responseType: "json",
+      });
+    } catch (error) {
+      throw new Error(
+        `Could not connect to Better BibTeX JSON-RPC at ${this.bbtRpcUrl}. ` +
+          `Make sure Better BibTeX is installed and enabled. ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+      );
+    }
+
+    if (response.status >= 400) {
+      throw new Error(
+        `Better BibTeX JSON-RPC returned HTTP ${response.status}`,
+      );
+    }
+
+    const data = response.response ?? JSON.parse(response.responseText ?? "{}");
+    if (data.error) {
+      throw new Error(
+        `Better BibTeX JSON-RPC error: ${
+          data.error.message ?? JSON.stringify(data.error)
+        }`,
+      );
+    }
+
+    return data.result;
+  }
+
+  private async resolveCitekeys(
+    itemKeys: string[],
+    libraryID?: number,
+  ): Promise<{
+    citekeys: string[];
+    map: Record<string, string>;
+    missing: string[];
+  }> {
+    const lookupKeys = itemKeys.map((itemKey) =>
+      libraryID === undefined || libraryID === null
+        ? itemKey
+        : `${libraryID}:${itemKey}`,
+    );
+
+    const result = (await this.bbtRpc("item.citationkey", [lookupKeys])) ?? {};
+    const map: Record<string, string> = {};
+    const citekeys: string[] = [];
+    const missing: string[] = [];
+
+    itemKeys.forEach((itemKey, index) => {
+      const citekey = result[lookupKeys[index]] ?? result[itemKey];
+      if (citekey) {
+        map[itemKey] = String(citekey);
+        citekeys.push(String(citekey));
+      } else {
+        missing.push(itemKey);
+      }
+    });
+
+    return { citekeys, map, missing };
+  }
+
+  async exportBibliography(params: {
+    itemKeys: string[];
+    format?: "biblatex" | "bibtex" | "csljson" | "cslyaml";
+    libraryID?: number;
+  }): Promise<any> {
+    const { itemKeys, format = "biblatex", libraryID } = params;
+
+    if (!Array.isArray(itemKeys) || itemKeys.length === 0) {
+      throw new Error("itemKeys must contain at least one Zotero item key");
+    }
+
+    const translator = BBT_TRANSLATORS[format];
+    if (!translator) {
+      throw new Error(
+        `Unsupported export format "${format}". ` +
+          "Use biblatex, bibtex, csljson, or cslyaml.",
+      );
+    }
+
+    const { citekeys, map, missing } = await this.resolveCitekeys(
+      itemKeys,
+      libraryID,
+    );
+    if (citekeys.length === 0) {
+      throw new Error(
+        `Better BibTeX could not resolve citation keys for: ${missing.join(", ")}`,
+      );
+    }
+
+    const rpcParams: any[] = [citekeys, translator];
+    if (libraryID !== undefined && libraryID !== null) {
+      rpcParams.push(libraryID);
+    }
+
+    const content = await this.bbtRpc("item.export", rpcParams);
+
+    ztoolkit.log(
+      `[CitationExport] exportBibliography: format=${format}, exported=${citekeys.length}, missing=${missing.length}`,
+    );
+
+    return {
+      format,
+      content: String(content ?? ""),
+      exportedCount: citekeys.length,
+      citationKeys: citekeys,
+      itemKeyToCitationKey: map,
+      ...(missing.length > 0 ? { missingKeys: missing } : {}),
+    };
+  }
+
+  private resolveStyle(style: string): {
+    styleID: string;
+    title: string;
+    hasBibliography: boolean;
+  } | null {
+    const candidates = [style];
+    if (!style.includes("://")) {
+      candidates.push(`http://www.zotero.org/styles/${style}`);
+    }
+
+    for (const candidate of candidates) {
+      try {
+        const resolved = Zotero.Styles.get(candidate);
+        if (resolved) {
+          return {
+            styleID: resolved.styleID,
+            title: resolved.title,
+            hasBibliography: resolved.hasBibliography,
+          };
+        }
+      } catch {
+        // Continue with title matching below.
+      }
+    }
+
+    const normalized = style.toLowerCase();
+    const styles = Zotero.Styles.getVisible();
+    const exact = styles.find(
+      (candidate: any) => candidate.title.toLowerCase() === normalized,
+    );
+    const partial =
+      exact ??
+      styles.find((candidate: any) =>
+        candidate.title.toLowerCase().includes(normalized),
+      );
+
+    if (!partial) return null;
+
+    return {
+      styleID: partial.styleID,
+      title: partial.title,
+      hasBibliography: partial.hasBibliography,
+    };
+  }
+
+  private getDefaultQuickCopyFormat(contentType: CitationContentType): {
+    format: any;
+    styleInfo: StyleInfo;
+  } {
+    const rawSetting = Zotero.Prefs.get("export.quickCopy.setting") as any;
+    const parsed = (Zotero.QuickCopy as any).unserializeSetting(rawSetting);
+
+    if (parsed?.mode === "bibliography" && parsed?.id) {
+      let title: string | undefined;
+      let hasBibliography: boolean | undefined;
+      try {
+        const style = Zotero.Styles.get(parsed.id);
+        title = style?.title;
+        hasBibliography = style?.hasBibliography;
+      } catch {
+        // A stale Quick Copy style will fail naturally when Quick Copy runs.
+      }
+
+      return {
+        format: {
+          ...parsed,
+          mode: "bibliography",
+          contentType,
+        },
+        styleInfo: {
+          id: parsed.id,
+          title,
+          isDefault: true,
+          hasBibliography,
+        },
+      };
+    }
+
+    return {
+      format: {
+        mode: "bibliography",
+        id: APA_STYLE_ID,
+        contentType,
+        locale: "",
+      },
+      styleInfo: {
+        id: APA_STYLE_ID,
+        title: "APA (fallback)",
+        isDefault: true,
+      },
+    };
+  }
+
+  async getCitation(params: {
+    itemKeys: string[];
+    style?: string;
+    contentType?: CitationContentType;
+    mode?: CitationMode;
+    libraryID?: number;
+  }): Promise<any> {
+    const {
+      itemKeys,
+      style,
+      contentType = "html",
+      mode = "bibliography",
+      libraryID,
+    } = params;
+
+    if (!Array.isArray(itemKeys) || itemKeys.length === 0) {
+      throw new Error("itemKeys must contain at least one Zotero item key");
+    }
+
+    const resolvedLibraryID =
+      libraryID !== undefined && libraryID !== null
+        ? libraryID
+        : Zotero.Libraries.userLibraryID;
+
+    const items: Zotero.Item[] = [];
+    const missing: string[] = [];
+    const skipped: string[] = [];
+
+    for (const itemKey of itemKeys) {
+      const item = await Zotero.Items.getByLibraryAndKeyAsync(
+        resolvedLibraryID,
+        itemKey,
+      );
+      if (!item) {
+        missing.push(itemKey);
+      } else if (item.isAttachment() || item.isNote()) {
+        skipped.push(itemKey);
+      } else {
+        items.push(item);
+      }
+    }
+
+    if (items.length === 0) {
+      throw new Error(
+        "No citable Zotero items were found for the supplied itemKeys",
+      );
+    }
+
+    let format: any;
+    let styleInfo: StyleInfo;
+
+    if (style) {
+      const resolved = this.resolveStyle(style);
+      if (!resolved) {
+        throw new Error(
+          `Citation style "${style}" was not found. ` +
+            "Use list_citation_styles to inspect available styles.",
+        );
+      }
+
+      format = {
+        mode: "bibliography",
+        id: resolved.styleID,
+        contentType,
+        locale: "",
+      };
+      styleInfo = {
+        id: resolved.styleID,
+        title: resolved.title,
+        isDefault: false,
+        hasBibliography: resolved.hasBibliography,
+      };
+    } else {
+      ({ format, styleInfo } = this.getDefaultQuickCopyFormat(contentType));
+    }
+
+    const asCitations = mode === "citation";
+    let result: any;
+    try {
+      result = (Zotero.QuickCopy as any).getContentFromItems(
+        items,
+        format,
+        undefined,
+        asCitations,
+      );
+    } catch (error) {
+      throw new Error(
+        `Failed to generate ${mode}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+
+    if (!result || typeof result !== "object") {
+      throw new Error(
+        "Zotero Quick Copy did not return citation content. " +
+          "The selection may exceed the configured Quick Copy item limit.",
+      );
+    }
+
+    ztoolkit.log(
+      `[CitationExport] getCitation: mode=${mode}, style=${styleInfo.id ?? "default"}, items=${items.length}, missing=${missing.length}, skipped=${skipped.length}`,
+    );
+
+    return {
+      mode,
+      style: styleInfo.id,
+      styleTitle: styleInfo.title,
+      isDefaultStyle: styleInfo.isDefault,
+      content:
+        contentType === "html" ? (result.html ?? result.text) : result.text,
+      itemCount: items.length,
+      ...(missing.length > 0 ? { missingKeys: missing } : {}),
+      ...(skipped.length > 0 ? { skippedKeys: skipped } : {}),
+    };
+  }
+
+  async listStyles(filter?: string): Promise<any> {
+    try {
+      await (Zotero.Schema as any).schemaUpdatePromise;
+    } catch {
+      // Style discovery can still work if the schema promise is unavailable.
+    }
+
+    const normalizedFilter = filter?.trim().toLowerCase();
+    const styles = Zotero.Styles.getVisible()
+      .map((style: any) => ({ id: style.styleID, title: style.title }))
+      .filter(
+        (style: { id: string; title: string }) =>
+          !normalizedFilter ||
+          style.id.toLowerCase().includes(normalizedFilter) ||
+          style.title.toLowerCase().includes(normalizedFilter),
+      )
+      .sort((a: { title: string }, b: { title: string }) =>
+        a.title.localeCompare(b.title),
+      );
+
+    return {
+      total: styles.length,
+      styles,
+    };
+  }
+}

--- a/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
+++ b/zotero-mcp-plugin/src/modules/streamableMCPServer.ts
@@ -26,6 +26,7 @@ import {
   notifierSaveOptions,
   runSerializedWrite,
 } from './deferredNotifierCommitter';
+import { CitationExportService } from './citationExportService';
 
 export interface MCPRequest {
   jsonrpc: '2.0';
@@ -1131,6 +1132,76 @@ export class StreamableMCPServer {
             }
           }
         }
+      },
+      {
+        name: 'export_bibliography',
+        description: 'Export one or more Zotero items as BibLaTeX/BibTeX (or CSL-JSON/CSL-YAML) entries using Better BibTeX. Requires Better BibTeX to be installed and running.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
+            itemKeys: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Item keys to export, e.g. ["ABCD1234","EFGH5678"]'
+            },
+            format: {
+              type: 'string',
+              enum: ['biblatex', 'bibtex', 'csljson', 'cslyaml'],
+              description: 'Export format. Defaults to biblatex.'
+            }
+          },
+          required: ['itemKeys']
+        }
+      },
+      {
+        name: 'get_citation',
+        description: 'Generate a formatted bibliography entry or in-text citation using a CSL style. If style is omitted, uses the Zotero default Quick Copy style. Uses Zotero native citeproc and does not require Better BibTeX.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            libraryID: {
+              type: 'number',
+              description: 'Optional target Zotero library ID. Defaults to the user library when omitted.'
+            },
+            itemKeys: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Item keys to cite, e.g. ["ABCD1234"]'
+            },
+            style: {
+              type: 'string',
+              description: 'Optional CSL style ID or title, e.g. "apa", "ieee", or a full Zotero style URL.'
+            },
+            contentType: {
+              type: 'string',
+              enum: ['html', 'text'],
+              description: 'Output content type. Defaults to html.'
+            },
+            mode: {
+              type: 'string',
+              enum: ['bibliography', 'citation'],
+              description: 'bibliography for full references or citation for in-text citations. Defaults to bibliography.'
+            }
+          },
+          required: ['itemKeys']
+        }
+      },
+      {
+        name: 'list_citation_styles',
+        description: 'List CSL citation styles available in Zotero for use with get_citation. Supports optional keyword filtering.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            filter: {
+              type: 'string',
+              description: 'Optional case-insensitive keyword to filter styles by title or ID.'
+            }
+          }
+        }
       }
     ];
 
@@ -1410,6 +1481,38 @@ export class StreamableMCPServer {
           result = await this.callAddByIdentifier(args);
           break;
         }
+
+        case 'export_bibliography': {
+          const exportKeys = this.coerceStringArray(args?.itemKeys);
+          if (!exportKeys || exportKeys.length === 0) {
+            throw new Error(
+              `itemKeys array is required, e.g. ["ABCD1234"]. Received: ${JSON.stringify(args?.itemKeys)}`,
+            );
+          }
+          result = await this.callExportBibliography({
+            ...args,
+            itemKeys: exportKeys,
+          });
+          break;
+        }
+
+        case 'get_citation': {
+          const citationKeys = this.coerceStringArray(args?.itemKeys);
+          if (!citationKeys || citationKeys.length === 0) {
+            throw new Error(
+              `itemKeys array is required, e.g. ["ABCD1234"]. Received: ${JSON.stringify(args?.itemKeys)}`,
+            );
+          }
+          result = await this.callGetCitation({
+            ...args,
+            itemKeys: citationKeys,
+          });
+          break;
+        }
+
+        case 'list_citation_styles':
+          result = await this.callListCitationStyles(args);
+          break;
 
         default:
           throw new Error(`Unknown tool: ${name}`);
@@ -1801,6 +1904,39 @@ export class StreamableMCPServer {
     }
     const result = response.body ? JSON.parse(response.body) : response;
     return result;
+  }
+
+  // ============ Citation & Bibliography Export Methods ============
+
+  private citationExportService: CitationExportService | null = null;
+
+  private getCitationExportService(): CitationExportService {
+    if (!this.citationExportService) {
+      this.citationExportService = new CitationExportService();
+    }
+    return this.citationExportService;
+  }
+
+  private async callExportBibliography(args: any): Promise<any> {
+    return this.getCitationExportService().exportBibliography({
+      itemKeys: args.itemKeys,
+      format: args.format,
+      libraryID: args.libraryID,
+    });
+  }
+
+  private async callGetCitation(args: any): Promise<any> {
+    return this.getCitationExportService().getCitation({
+      itemKeys: args.itemKeys,
+      style: args.style,
+      contentType: args.contentType,
+      mode: args.mode,
+      libraryID: args.libraryID,
+    });
+  }
+
+  private async callListCitationStyles(args: any): Promise<any> {
+    return this.getCitationExportService().listStyles(args?.filter);
   }
 
   // ============ Semantic Search Methods ============
@@ -3276,6 +3412,10 @@ export class StreamableMCPServer {
         'get_collection_items',
         'search_fulltext',
         'get_item_abstract',
+        // Citation & bibliography export tools (read-only)
+        'export_bibliography',
+        'get_citation',
+        'list_citation_styles',
         // Semantic Search Tools (read-only)
         'semantic_search',
         'find_similar',

--- a/zotero-mcp-plugin/test/citationExportService.test.ts
+++ b/zotero-mcp-plugin/test/citationExportService.test.ts
@@ -1,0 +1,129 @@
+import { CitationExportService } from "../src/modules/citationExportService";
+
+declare const expect: Chai.ExpectStatic;
+
+const QUICK_COPY_PREF = "export.quickCopy.setting";
+
+describe("CitationExportService", function () {
+  beforeEach(function () {
+    (globalThis as any).ztoolkit = { log: () => undefined };
+  });
+
+  it("maps Zotero item keys to BBT citation keys before export", async function () {
+    const service = new CitationExportService();
+    const calls: Array<{ method: string; params: any[] }> = [];
+
+    (service as any).bbtRpc = async (method: string, params: any[]) => {
+      calls.push({ method, params });
+      if (method === "item.citationkey") {
+        return { "12:ABCD1234": "Doe2026" };
+      }
+      if (method === "item.export") {
+        return "@article{Doe2026, title={Example}}";
+      }
+      throw new Error(`Unexpected RPC method: ${method}`);
+    };
+
+    const result = await service.exportBibliography({
+      itemKeys: ["ABCD1234"],
+      format: "biblatex",
+      libraryID: 12,
+    });
+
+    expect(calls).to.deep.equal([
+      {
+        method: "item.citationkey",
+        params: [["12:ABCD1234"]],
+      },
+      {
+        method: "item.export",
+        params: [["Doe2026"], "Better BibLaTeX", 12],
+      },
+    ]);
+    expect(result.citationKeys).to.deep.equal(["Doe2026"]);
+    expect(result.itemKeyToCitationKey).to.deep.equal({
+      ABCD1234: "Doe2026",
+    });
+  });
+
+  it("uses bibliography Quick Copy mode and the fourth argument for in-text citations", async function () {
+    const service = new CitationExportService();
+    const item = new Zotero.Item("journalArticle");
+    item.libraryID = Zotero.Libraries.userLibraryID;
+    item.setField("title", "Citation regression test");
+    await item.saveTx({ skipNotifier: true });
+
+    const quickCopy = Zotero.QuickCopy as any;
+    const originalGetContentFromItems = quickCopy.getContentFromItems;
+    let capturedArgs: any[] | undefined;
+
+    quickCopy.getContentFromItems = (...args: any[]) => {
+      capturedArgs = args;
+      return {
+        text: "(Test, 2026)",
+        html: "<span>(Test, 2026)</span>",
+      };
+    };
+
+    try {
+      const result = await service.getCitation({
+        itemKeys: [item.key],
+        style: "apa",
+        mode: "citation",
+        contentType: "text",
+      });
+
+      expect(capturedArgs).to.not.equal(undefined);
+      expect(capturedArgs![1].mode).to.equal("bibliography");
+      expect(capturedArgs![2]).to.equal(undefined);
+      expect(capturedArgs![3]).to.equal(true);
+      expect(result.content).to.equal("(Test, 2026)");
+    } finally {
+      quickCopy.getContentFromItems = originalGetContentFromItems;
+      await item.eraseTx({ skipNotifier: true });
+    }
+  });
+
+  it("parses bibliography/html Quick Copy settings instead of falling back", async function () {
+    const service = new CitationExportService();
+    const item = new Zotero.Item("journalArticle");
+    item.libraryID = Zotero.Libraries.userLibraryID;
+    item.setField("title", "Quick Copy parsing test");
+    await item.saveTx({ skipNotifier: true });
+
+    const previousSetting = Zotero.Prefs.get(QUICK_COPY_PREF) as any;
+    const testStyleID = "http://www.zotero.org/styles/review-test-style";
+    Zotero.Prefs.set(QUICK_COPY_PREF, `bibliography/html=${testStyleID}`, true);
+
+    const quickCopy = Zotero.QuickCopy as any;
+    const originalGetContentFromItems = quickCopy.getContentFromItems;
+    let capturedFormat: any;
+
+    quickCopy.getContentFromItems = (_items: any[], format: any) => {
+      capturedFormat = format;
+      return { text: "text", html: "<span>html</span>" };
+    };
+
+    try {
+      const result = await service.getCitation({
+        itemKeys: [item.key],
+        mode: "bibliography",
+        contentType: "html",
+      });
+
+      expect(capturedFormat.mode).to.equal("bibliography");
+      expect(capturedFormat.contentType).to.equal("html");
+      expect(capturedFormat.id).to.equal(testStyleID);
+      expect(result.style).to.equal(testStyleID);
+      expect(result.isDefaultStyle).to.equal(true);
+    } finally {
+      quickCopy.getContentFromItems = originalGetContentFromItems;
+      if (previousSetting === undefined || previousSetting === null) {
+        Zotero.Prefs.clear(QUICK_COPY_PREF);
+      } else {
+        Zotero.Prefs.set(QUICK_COPY_PREF, previousSetting, true);
+      }
+      await item.eraseTx({ skipNotifier: true });
+    }
+  });
+});


### PR DESCRIPTION
Split the read-only citation/export work from cookjohn/zotero-mcp#92.

- add Better BibTeX-backed export_bibliography
- add Zotero-native get_citation and list_citation_styles
- fix Quick Copy citation mode/callback/default-setting handling
- add regression coverage for BBT export and Quick Copy behavior